### PR TITLE
Move halo field to output tensor specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Must be a list of *tensor specification keys*.
        - `reference_input` name of the reference input tensor
        - `scale` list of factors 'output_pix/input_pix' for each dimension
        - `offset` position of origin wrt to input 
-       - `halo` the halo to crop from the output tensor (for example to crop away boundary efects or for tiling). The halo should be croped from both sides, i.e. `shape_after_crop = shape - 2 * halo`. The `halo` is not cropped by the bioimage.io model, but is left to be cropped by the consumer software. Use `offset` if the model output itself is cropped.
+  - `halo` \[optional\] (only for output) the halo to crop from the output tensor (for example to crop away boundary efects or for tiling). The halo should be croped from both sides, i.e. `shape_after_crop = shape - 2 * halo`. The `halo` is not cropped by the bioimage.io model, but is left to be cropped by the consumer software. Use `shape:offset` if the model output itself is cropped.
   - `preprocessing` \[optional\] (only for input) list of transformations describing how this input should be preprocessed. Each entry has these keys:
     - `name` name of preprocessing (see [supported_formats_and_operations.md#preprocessing](https://github.com/bioimage-io/configuration/blob/master/supported_formats_and_operations.md#preprocessing) for valid names).
     - `kwargs` \[optional\] key word arguments for `preprocessing`.


### PR DESCRIPTION
Similar to #71, but add more description.

Note that specifying `halo` as a field in `shape` is inconsistent with the direct specification of the spec, as pointed out here https://github.com/bioimage-io/python-bioimage-io/issues/56#issuecomment-826876674.
Hence, we have to move it one level up in the hierarchy.