### PR TITLE
Use SPDX license identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It is recommended to:
  * the model folder can be packaged into a zip file, and the package name should use a descriptive name + `.model.zip`.
  * use or upgrade to the latest format version
 
-## Current `format_version`: 0.3.1
+## Current `format_version`: 0.3.2
 
 A model entry in the bioimage.io model zoo is defined by a configuration file `model.yaml`.
 The configuration file must contain the following fields; optional fields are followed by \[optional\].
@@ -212,3 +212,6 @@ with open(filename, "rb") as f:
 # Example Configurations
 ## PyTorch
  - [UNet 2D Nuclei Broad](https://github.com/bioimage-io/pytorch-bioimage-io/blob/master/specs/models/unet2d_nuclei_broad/UNet2DNucleiBroad.model.yaml).
+
+# Changelog
+ * **0.3.2**: Only allow `license` identifier from the SPDX license list

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If the model is contained in a subfolder of a git repository, then a url to the 
 A list of tags.
 
 - `license`
-A string to a common license name (e.g. `MIT`, `APLv2`) or a relative path to the license file.
+A [SPDX license identifier](https://spdx.org/licenses/)(e.g. `CC-BY-4.0`, `MIT`, `BSD-2-Clause`) or a relative path to the license file.
 
 - `documentation`
 Relative path to file with additional documentation in markdown.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If the model is contained in a subfolder of a git repository, then a url to the 
 A list of tags.
 
 - `license`
-A [SPDX license identifier](https://spdx.org/licenses/)(e.g. `CC-BY-4.0`, `MIT`, `BSD-2-Clause`) or a relative path to the license file.
+A [SPDX license identifier](https://spdx.org/licenses/)(e.g. `CC-BY-4.0`, `MIT`, `BSD-2-Clause`). We don't support custom license beyond the SPDX license list, if you need that please send an Github issue to discuss your intentions with the community.
 
 - `documentation`
 Relative path to file with additional documentation in markdown.


### PR DESCRIPTION
Right now, we haven't define how the license identifier should be specified. I saw Zenodo uses SPDX identifier and I think we should basically enforce the same. 

Here is a list of them: https://spdx.org/licenses/