### PR TITLE
Support describing author affiliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It is recommended to:
  * the model folder can be packaged into a zip file, and the package name should use a descriptive name + `.model.zip`.
  * use or upgrade to the latest format version
 
-## Current `format_version`: 0.3.2
+## Current `format_version`: 0.3.3
 
 A model entry in the bioimage.io model zoo is defined by a configuration file `model.yaml`.
 The configuration file must contain the following fields; optional fields are followed by \[optional\].
@@ -215,4 +215,4 @@ with open(filename, "rb") as f:
 
 
 # Changelog
- * **0.3.2**: each author in `authors` can be a dictionary with `name` and `affiliation`.
+ * **0.3.3**: Each author in `authors` can be a dictionary with `name` and `affiliation` or a name string.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It is recommended to:
  * the model folder can be packaged into a zip file, and the package name should use a descriptive name + `.model.zip`.
  * use or upgrade to the latest format version
 
-## Current `format_version`: 0.3.1
+## Current `format_version`: 0.3.2
 
 A model entry in the bioimage.io model zoo is defined by a configuration file `model.yaml`.
 The configuration file must contain the following fields; optional fields are followed by \[optional\].
@@ -38,9 +38,9 @@ Timestamp of the initial creation of this model in [ISO 8601](#https://en.wikipe
 A string containing a brief description. 
 
 - `authors`
-A list of author strings. 
-A string can be seperated by `;` in order to identify multiple handles per author.
-The authors are the creators of the specifications and the primary points of contact.
+A list of authors, each author can be a string with the author name only or a dictionary contains `name` and `affiliation` of the author. 
+A author name string can be seperated by `;` in order to identify multiple handles per author.
+The authors are the creators of the model and the primary points of contact.
 
 - `cite` \[optional\]
 A citation entry or list of citation entries.
@@ -212,3 +212,7 @@ with open(filename, "rb") as f:
 # Example Configurations
 ## PyTorch
  - [UNet 2D Nuclei Broad](https://github.com/bioimage-io/pytorch-bioimage-io/blob/master/specs/models/unet2d_nuclei_broad/UNet2DNucleiBroad.model.yaml).
+
+
+# Changelog
+ * **0.3.2**: each author in `authors` can be a dictionary with `name` and `affiliation`.


### PR DESCRIPTION
Currently, the authors in the `authors` list is author name string only. But Zenodo requires each author has `name` and `affiliation`. I think it might be better if we can also support author dictionary.

There can be two ways to support this, 1) allowing both a string and a dictionary so we can be backward compatible 2) migrate to dictionary only, and we can provide automatic conversion in the packager (similar to the `axes`).

What do you think?