### PR TITLE
Add a `type` and `version` key

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ If a field is followed by \[optional\]\*, they are optional depending on another
 Version of this bioimage.io configuration specification. This is mandatory, and important for the consumer software to verify before parsing the fields.
 The recommended behavior for the implementation is to keep backward compatibility, and throw error if the model yaml is in an unsupported format version.
 
+- `type`
+The value must be `model`, used to differentiate with other RDF types such as `dataset`, `application`.
+
 - `name`
 Name of this model. The model name should be human readble and only contain letters, numbers, `_`, `-` or spaces and not be longer than 36 characters.
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ The recommended behavior for the implementation is to keep backward compatibilit
 - `type`
 The value must be `model`, used to differentiate with other RDF types such as `dataset`, `application`.
 
-- `version`
-The version number of the model. The version number format must be a string in `MAJOR.MINOR.PATCH` format following the guidelines in Semantic Versioning 2.0.0 (see https://semver.org/).
+- `version` \[optional\]
+The version number of the model. The version number format must be a string in `MAJOR.MINOR.PATCH` format following the guidelines in Semantic Versioning 2.0.0 (see https://semver.org/), e.g. the initial verision number should be `0.1.0`.
 
 - `name`
 Name of this model. The model name should be human readble and only contain letters, numbers, `_`, `-` or spaces and not be longer than 36 characters.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ The recommended behavior for the implementation is to keep backward compatibilit
 - `type`
 The value must be `model`, used to differentiate with other RDF types such as `dataset`, `application`.
 
+- `version`
+The version number of the model. The version number format must be a string in `MAJOR.MINOR.PATCH` format following the guidelines in Semantic Versioning 2.0.0 (see https://semver.org/).
+
 - `name`
 Name of this model. The model name should be human readble and only contain letters, numbers, `_`, `-` or spaces and not be longer than 36 characters.
 


### PR DESCRIPTION
In the RDF definition we have the `type` and `version` key, it would be nice if we can add it for the models as well.

Todo: bump version and add changelog