### PR TITLE
Add support for missing weight formats to build_spec

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,3 +32,8 @@ def UNet2DNucleiBroad_model_url():
         "https://raw.githubusercontent.com/bioimage-io/pytorch-bioimage-io/25f6bac5a22d8a76553bd4484a515f634bcb9ee2/"
         "specs/models/unet2d_nuclei_broad/UNet2DNucleiBroad.model.yaml"
     )
+
+
+@pytest.fixture
+def FruNet_model_url():
+    return "https://raw.githubusercontent.com/deepimagej/models/master/fru-net_sev_segmentation/model.yaml"

--- a/tests/test_utils/test_build_spec.py
+++ b/tests/test_utils/test_build_spec.py
@@ -104,7 +104,6 @@ def test_build_spec_onnx(UNet2DNucleiBroad_model_url):
     cite = {entry["text"]: entry["doi"] if "doi" in entry else entry["url"] for entry in source["cite"]}
 
     raw_model = build_spec(
-        model_kwargs=source["kwargs"],
         weight_uri=weight_source,
         test_inputs=test_inputs,
         test_outputs=test_outputs,
@@ -142,7 +141,6 @@ def test_build_spec_torchscript(UNet2DNucleiBroad_model_url):
     cite = {entry["text"]: entry["doi"] if "doi" in entry else entry["url"] for entry in source["cite"]}
 
     raw_model = build_spec(
-        model_kwargs=source["kwargs"],
         weight_uri=weight_source,
         test_inputs=test_inputs,
         test_outputs=test_outputs,
@@ -157,5 +155,110 @@ def test_build_spec_torchscript(UNet2DNucleiBroad_model_url):
         cite=cite,
         weight_type="pytorch_script",
     )
+    serialized = schema.Model().dump(raw_model)
+    assert type(serialized) == type(source)
+
+
+def test_build_spec_keras(FruNet_model_url):
+    from bioimageio.spec.utils.build_spec import build_spec, _get_local_path
+
+    config_path = _get_local_path(FruNet_model_url)
+    assert os.path.exists(config_path), config_path
+    source = yaml.load(Path(config_path))
+
+    weight_source = "https://zenodo.org/record/4156050/files/fully_residual_dropout_segmentation.h5"
+    test_inputs = [
+        "https://github.com/deepimagej/models/raw/master/fru-net_sev_segmentation/exampleImage.npy"
+    ]
+    test_outputs = [
+        "https://github.com/deepimagej/models/raw/master/fru-net_sev_segmentation/resultImage.npy"
+    ]
+    cite = {entry["text"]: entry["doi"] if "doi" in entry else entry["url"] for entry in source["cite"]}
+
+    raw_model = build_spec(
+        weight_uri=weight_source,
+        test_inputs=test_inputs,
+        test_outputs=test_outputs,
+        name=source["name"],
+        description=source["description"],
+        authors=source["authors"],
+        tags=source["tags"],
+        license=source["license"],
+        documentation=source["documentation"],
+        covers=source["covers"],
+        cite=cite,
+        tensorflow_version="1.12"
+    )
+
+    serialized = schema.Model().dump(raw_model)
+    assert type(serialized) == type(source)
+
+
+def test_build_spec_tf(FruNet_model_url):
+    from bioimageio.spec.utils.build_spec import build_spec, _get_local_path
+
+    config_path = _get_local_path(FruNet_model_url)
+    assert os.path.exists(config_path), config_path
+    source = yaml.load(Path(config_path))
+
+    weight_source = "https://zenodo.org/record/4156050/files/tensorflow_saved_model_bundle.zip"
+    test_inputs = [
+        "https://github.com/deepimagej/models/raw/master/fru-net_sev_segmentation/exampleImage.npy"
+    ]
+    test_outputs = [
+        "https://github.com/deepimagej/models/raw/master/fru-net_sev_segmentation/resultImage.npy"
+    ]
+    cite = {entry["text"]: entry["doi"] if "doi" in entry else entry["url"] for entry in source["cite"]}
+
+    raw_model = build_spec(
+        weight_uri=weight_source,
+        test_inputs=test_inputs,
+        test_outputs=test_outputs,
+        name=source["name"],
+        description=source["description"],
+        authors=source["authors"],
+        tags=source["tags"],
+        license=source["license"],
+        documentation=source["documentation"],
+        covers=source["covers"],
+        cite=cite,
+        tensorflow_version="1.12"
+    )
+
+    serialized = schema.Model().dump(raw_model)
+    assert type(serialized) == type(source)
+
+
+def test_build_spec_tfjs(FruNet_model_url):
+    from bioimageio.spec.utils.build_spec import build_spec, _get_local_path
+
+    config_path = _get_local_path(FruNet_model_url)
+    assert os.path.exists(config_path), config_path
+    source = yaml.load(Path(config_path))
+
+    weight_source = ("https://raw.githubusercontent.com/deepimagej/tensorflow-js-models/main/"
+                     "fru-net_sev_segmentation_tf_js_model/model.json")
+    test_inputs = [
+        "https://github.com/deepimagej/models/raw/master/fru-net_sev_segmentation/exampleImage.npy"
+    ]
+    test_outputs = [
+        "https://github.com/deepimagej/models/raw/master/fru-net_sev_segmentation/resultImage.npy"
+    ]
+    cite = {entry["text"]: entry["doi"] if "doi" in entry else entry["url"] for entry in source["cite"]}
+
+    raw_model = build_spec(
+        weight_uri=weight_source,
+        test_inputs=test_inputs,
+        test_outputs=test_outputs,
+        name=source["name"],
+        description=source["description"],
+        authors=source["authors"],
+        tags=source["tags"],
+        license=source["license"],
+        documentation=source["documentation"],
+        covers=source["covers"],
+        cite=cite
+    )
+
     serialized = schema.Model().dump(raw_model)
     assert type(serialized) == type(source)


### PR DESCRIPTION
See #87. 

@FynnBe I think the changes here are correct, however the tests fail. I think the reason is that the example model for keras/tf at https://github.com/deepimagej/models/blob/master/fru-net_sev_segmentation/model.yaml does not conform with the current spec.
It would be good to check why and see if this is an issue in the checker or with the model itself.