### PR TITLE
Fix the restriction on type key for general RDF

### DIFF
--- a/bioimageio/spec/v0_3/raw_nodes.py
+++ b/bioimageio/spec/v0_3/raw_nodes.py
@@ -37,7 +37,7 @@ PreprocessingName = Literal["binarize", "clip", "scale_linear", "sigmoid", "zero
 PostprocessingName = Literal[
     "binarize", "clip", "scale_linear", "sigmoid", "zero_mean_unit_variance", "scale_range", "scale_mean_variance"
 ]
-Type = Literal["model", "dataset", "application", "notebook"]
+Type = NewType("Type", str)
 WeightsFormat = Literal[
     "pytorch_state_dict", "pytorch_script", "keras_hdf5", "tensorflow_js", "tensorflow_saved_model_bundle", "onnx"
 ]

--- a/bioimageio/spec/v0_3/raw_nodes.py
+++ b/bioimageio/spec/v0_3/raw_nodes.py
@@ -97,8 +97,6 @@ class RDF(Node):
         if self.type is missing:
             self.type = self.__class__.__name__.lower()  # noqa
 
-        assert self.type in get_args(Type)
-
 
 @dataclass
 class Preprocessing:

--- a/bioimageio/spec/v0_3/raw_nodes.py
+++ b/bioimageio/spec/v0_3/raw_nodes.py
@@ -37,7 +37,7 @@ PreprocessingName = Literal["binarize", "clip", "scale_linear", "sigmoid", "zero
 PostprocessingName = Literal[
     "binarize", "clip", "scale_linear", "sigmoid", "zero_mean_unit_variance", "scale_range", "scale_mean_variance"
 ]
-Type = NewType("Type", str)
+Type = str
 WeightsFormat = Literal[
     "pytorch_state_dict", "pytorch_script", "keras_hdf5", "tensorflow_js", "tensorflow_saved_model_bundle", "onnx"
 ]


### PR DESCRIPTION
In the general RDF, the type should not be enum but rather any string would be valid.

See the original definition here: https://github.com/bioimage-io/bioimage.io/blob/0002e32e587a9dcd588e3c83981ec4b80a93f835/docs/contribute_models/resource-description-file.md
