### PR TITLE
Remove pickle

### DIFF
--- a/bioimageio/spec/v0_3/schema.py
+++ b/bioimageio/spec/v0_3/schema.py
@@ -778,7 +778,6 @@ config:
             return
 
         weights_format_requires_source = {
-            "pickle": True,  # todo: remove
             "pytorch_state_dict": True,
             "pytorch_script": False,
             "keras_hdf5": False,


### PR DESCRIPTION
@FynnBe I think pickle format can be removed; it looks like it's removed everywhere else now:
```
$ grep -Inr pickle bioimageio/spec/
bioimageio/spec/v0_3/schema.py:781:            "pickle": True,  # todo: remove
```