### PR TITLE
fix bioimageio entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "typer",
         "typing-extensions",
     ],
-    entry_points={"console_scripts": ["bioimageio = bioimageio.spec:main"]},
+    entry_points={"console_scripts": ["bioimageio = bioimageio.spec.__main__:app"]},
     extras_require={"test": ["pytest", "tox", "torch", "numpy", "mypy"], "dev": ["pre-commit"]},
     scripts=["scripts/generate_docs.py"],
     package_data={"bioimageio.spec": ["static/licenses.json"]},


### PR DESCRIPTION
implmentation following https://github.com/bioimage-io/spec-bioimage-io/issues/160

There is no limit on ways how to fix this actually... 

I think it is neat to leave all typer tuff in __main__.py, thus the package itself does not even depend on typer. one can `import bioimageio.spec` without typer :-).. 
having the entry point defined in __main__.py means that our entry_points has to point there (instead of the plain module "__init__.py"). the name of the entry point function does not need to be 'main', so I kept it as `app`, which works just as well.

If any other implementation is preferred by anyone, please feel free to change it. I don't care how exactly this is solved, it should just work 💯 