### PR TITLE
make sure to include static data in source dist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
     extras_require={"test": ["pytest", "tox", "torch", "numpy", "mypy"], "dev": ["pre-commit"]},
     scripts=["scripts/generate_docs.py"],
     package_data={"bioimageio.spec": ["static/licenses.json"]},
-    include_package_data=True,
     project_urls={  # Optional
         "Bug Reports": "https://github.com/bioimage-io/spec-bioimage-io/issues",
         "Source": "https://github.com/bioimage-io/spec-bioimage-io",


### PR DESCRIPTION
Disclaimer: I couldn't reproduce the original issue locally, but our [current (0.3.2.rc0)
dist on pypi](https://files.pythonhosted.org/packages/29/e6/52646eb12b036ac83fd3d3ea0eb8a759d1e947be54755a71c1dc86cb07f8/bioimageio.spec-0.3.2rc0.tar.gz) does not include static/licenses.json

Reading about it, it looks like

* `include_package_data` will will include data from MANIFEST.in, which we don't have. SO at least that I removed.

Also note that the wheel seems to be intact.

@oeway do you have a good idea on how to debug this on the ci?


<details>

```bash
$: tar -xvf ~/Downloads/bioimageio.spec-0.3.2rc0.tar.gz 
bioimageio.spec-0.3.2rc0/
bioimageio.spec-0.3.2rc0/LICENSE
bioimageio.spec-0.3.2rc0/MANIFEST.in
bioimageio.spec-0.3.2rc0/PKG-INFO
bioimageio.spec-0.3.2rc0/README.md
bioimageio.spec-0.3.2rc0/bioimageio/
bioimageio.spec-0.3.2rc0/bioimageio/spec/
bioimageio.spec-0.3.2rc0/bioimageio/spec/VERSION
bioimageio.spec-0.3.2rc0/bioimageio/spec/__init__.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/__main__.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/build_spec.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/commands.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/converters.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/exceptions.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/nodes.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/raw_nodes.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/schema.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/shared/
bioimageio.spec-0.3.2rc0/bioimageio/spec/shared/__init__.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/shared/common.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/shared/field_validators.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/shared/fields.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/shared/io.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/shared/nodes.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/shared/raw_nodes.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/shared/schema.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/shared/utils.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/utils.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/v0_1/
bioimageio.spec-0.3.2rc0/bioimageio/spec/v0_1/__init__.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/v0_1/converters.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/v0_1/nodes.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/v0_1/raw_nodes.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/v0_1/schema.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/v0_1/utils.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/v0_3/
bioimageio.spec-0.3.2rc0/bioimageio/spec/v0_3/__init__.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/v0_3/converters.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/v0_3/nodes.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/v0_3/raw_nodes.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/v0_3/schema.py
bioimageio.spec-0.3.2rc0/bioimageio/spec/v0_3/utils.py
bioimageio.spec-0.3.2rc0/bioimageio.spec.egg-info/
bioimageio.spec-0.3.2rc0/bioimageio.spec.egg-info/PKG-INFO
bioimageio.spec-0.3.2rc0/bioimageio.spec.egg-info/SOURCES.txt
bioimageio.spec-0.3.2rc0/bioimageio.spec.egg-info/dependency_links.txt
bioimageio.spec-0.3.2rc0/bioimageio.spec.egg-info/entry_points.txt
bioimageio.spec-0.3.2rc0/bioimageio.spec.egg-info/requires.txt
bioimageio.spec-0.3.2rc0/bioimageio.spec.egg-info/top_level.txt
bioimageio.spec-0.3.2rc0/example_specs/
bioimageio.spec-0.3.2rc0/example_specs/models/
bioimageio.spec-0.3.2rc0/example_specs/models/unet2d_nuclei_broad/
bioimageio.spec-0.3.2rc0/example_specs/models/unet2d_nuclei_broad/unet2d.py
bioimageio.spec-0.3.2rc0/pyproject.toml
bioimageio.spec-0.3.2rc0/scripts/
bioimageio.spec-0.3.2rc0/scripts/generate_docs.py
bioimageio.spec-0.3.2rc0/scripts/generate_json_specs.py
bioimageio.spec-0.3.2rc0/scripts/generate_passthrough_modules.py
bioimageio.spec-0.3.2rc0/scripts/generate_weights_formats_overview.py
bioimageio.spec-0.3.2rc0/setup.cfg
bioimageio.spec-0.3.2rc0/setup.py
bioimageio.spec-0.3.2rc0/tests/
bioimageio.spec-0.3.2rc0/tests/test_versions/
bioimageio.spec-0.3.2rc0/tests/test_versions/test_v0_1.py
```

</details