### PR TITLE
add static data via manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include bioimageio/spec/VERSION
 include README.md
 include LICENSE
+include bioimageio/spec/static/licenses.json

--- a/bioimageio/spec/VERSION
+++ b/bioimageio/spec/VERSION
@@ -1,3 +1,3 @@
 {
-    "version": "0.3.2.rc0"
+    "version": "0.3.2.rc1"
 }

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
     entry_points={"console_scripts": ["bioimageio = bioimageio.spec.__main__:app"]},
     extras_require={"test": ["pytest", "tox", "torch", "numpy", "mypy"], "dev": ["pre-commit"]},
     scripts=["scripts/generate_docs.py"],
-    package_data={"bioimageio.spec": ["static/licenses.json"]},
     include_package_data=True,
     project_urls={  # Optional
         "Bug Reports": "https://github.com/bioimage-io/spec-bioimage-io/issues",


### PR DESCRIPTION
in the _source_ distribution of `bioimageio.spec` 0.3.2.rc0, the `static/licenses.json` file was not included, as there seem to be issues with having both `MANIFEST.in` and  in setup `package_data`.

Add all data the same way.

Also this bumps the version to `0.3.2.rc1` in order to check that it's working :)

superseeds #164 