### PR TITLE
Make the format_version independent

### DIFF
--- a/bioimageio/spec/v0_3/raw_nodes.py
+++ b/bioimageio/spec/v0_3/raw_nodes.py
@@ -84,7 +84,7 @@ class RDF(Node):
     covers: Union[_Missing, List[URI]] = missing
     description: str = missing
     documentation: Path = missing
-    format_version: ModelFormatVersion = missing
+    format_version: GeneralFormatVersion = missing
     git_repo: Union[_Missing, str] = missing
     license: Union[_Missing, str] = missing
     links: List[str] = missing
@@ -200,6 +200,7 @@ class ModelParent(Node):
 class Model(RDF):
     authors: List[Author] = missing  # type: ignore  # base RDF has List[Union[Author, str]], but should change soon
     dependencies: Union[_Missing, Dependencies] = missing
+    format_version: ModelFormatVersion = missing
     framework: Union[_Missing, Framework] = missing
     inputs: List[InputTensor] = missing
     kwargs: Union[_Missing, Dict[str, Any]] = missing


### PR DESCRIPTION
This PR implements independent version for general RDF and model RDF. I don't fully understand the codebase yet, please check and make sure I am doing it right. @FynnBe 