### PR TITLE
Fix general spec version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can find detailed field definitions here:
    - [general RDF spec 0.2.x](https://github.com/bioimage-io/spec-bioimage-io/blob/gh-pages/rdf_spec_v0_2.md)
 
 The specifications are also available as json schemas: 
-   - [general RDF spec 0.2.0 (json schema)](https://github.com/bioimage-io/spec-bioimage-io/blob/gh-pages/rdf_spec_v0_2_0.json)
+   - [general RDF spec 0.2.x (json schema)](https://github.com/bioimage-io/spec-bioimage-io/blob/gh-pages/rdf_spec_v0_2.json)
 
 
 ### Describing applications

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ As a general guideline, please follow the model RDF spec to describe AI models a
 A BioImage.IO-compatible Resource Description File (RDF) is a YAML file with a set of specifically defined fields. 
 
 You can find detailed field definitions here: 
-   - [general RDF spec 0.3](https://github.com/bioimage-io/spec-bioimage-io/blob/gh-pages/rdf_spec_v0_3.md)
+   - [general RDF spec 0.2.0](https://github.com/bioimage-io/spec-bioimage-io/blob/gh-pages/rdf_spec_v0_2_0.md)
 
 The specifications are also available as json schemas: 
-   - [general RDF spec 0.3 (json schema)](https://github.com/bioimage-io/spec-bioimage-io/blob/gh-pages/rdf_spec_v0_3.json)
+   - [general RDF spec 0.2.0 (json schema)](https://github.com/bioimage-io/spec-bioimage-io/blob/gh-pages/rdf_spec_v0_2_0.json)
 
 
 ### Describing applications

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ As a general guideline, please follow the model RDF spec to describe AI models a
 A BioImage.IO-compatible Resource Description File (RDF) is a YAML file with a set of specifically defined fields. 
 
 You can find detailed field definitions here: 
-   - [general RDF spec 0.2.0](https://github.com/bioimage-io/spec-bioimage-io/blob/gh-pages/rdf_spec_v0_2_0.md)
+   - [general RDF spec 0.2.x](https://github.com/bioimage-io/spec-bioimage-io/blob/gh-pages/rdf_spec_v0_2.md)
 
 The specifications are also available as json schemas: 
    - [general RDF spec 0.2.0 (json schema)](https://github.com/bioimage-io/spec-bioimage-io/blob/gh-pages/rdf_spec_v0_2_0.json)

--- a/scripts/generate_json_specs.py
+++ b/scripts/generate_json_specs.py
@@ -5,6 +5,11 @@ from marshmallow_jsonschema import JSONSchema
 
 import bioimageio.spec
 
+try:
+    from typing import get_args
+except ImportError:
+    from typing_extensions import get_args  # type: ignore
+
 
 def export_json_schema_from_schema(path: Path, schema: bioimageio.spec.schema.SharedBioImageIOSchema):
     with path.open("w") as f:
@@ -14,12 +19,14 @@ def export_json_schema_from_schema(path: Path, schema: bioimageio.spec.schema.Sh
 
 def export_json_schemas(folder: Path, spec=bioimageio.spec):
     if spec == bioimageio.spec:
-        format_version_wo_patch = "latest"
+        model_format_version_wo_patch = "latest"
+        general_format_version_wo_patch = "latest"
     else:
-        format_version_wo_patch = spec.__name__.split(".")[-1]
+        model_format_version_wo_patch = spec.__name__.split(".")[-1]
+        general_format_version_wo_patch = ".".join(get_args(spec.raw_nodes.GeneralFormatVersion)[-1].split(".")[:2])
 
-    export_json_schema_from_schema(folder / f"model_spec_{format_version_wo_patch}.json", spec.schema.Model())
-    export_json_schema_from_schema(folder / f"rdf_spec_{format_version_wo_patch}.json", spec.schema.RDF())
+    export_json_schema_from_schema(folder / f"model_spec_{model_format_version_wo_patch}.json", spec.schema.Model())
+    export_json_schema_from_schema(folder / f"rdf_spec_{general_format_version_wo_patch}.json", spec.schema.RDF())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes the general RDF URL in README.

@FynnBe Could you help with fixing the json schema file generation for the general RDF? The current one are named 0.3, see here in the gh-pages branch: https://github.com/bioimage-io/spec-bioimage-io/tree/gh-pages