### PR TITLE
Generate the supported_weight_formats key

### DIFF
--- a/scripts/generate_weights_formats_overview.py
+++ b/scripts/generate_weights_formats_overview.py
@@ -38,6 +38,10 @@ def main(args):
     collection = collection["collections"]
 
     consumers = {c["id"]: c for c in collection}
+    for consumer in consumers.values():
+        if consumer["id"] in consumer_defaults:
+            consumer["config"] = consumer.get("config", {})
+            consumer["config"]["supported_weight_formats"] = consumer_defaults[consumer["id"]]
 
     weights_format_ids = get_args(WeightsFormat)
     weights_format_class_names = [wf.title().replace("_", "") + "WeightsEntry" for wf in weights_format_ids]


### PR DESCRIPTION
For the packager we need a list of supported weight formats in the json file.