### PR TITLE
prefer pytorch_state_dict for ilastik

### DIFF
--- a/scripts/generate_weights_formats_overview.py
+++ b/scripts/generate_weights_formats_overview.py
@@ -14,7 +14,7 @@ WEIGHTS_FORMATS_OVERVIEW_PATH = (
 
 # defaults for transition period
 consumer_defaults = {
-    "ilastik": ["pytorch_script", "onnx", "pytorch_state_dict"],
+    "ilastik": ["pytorch_state_dict", "onnx", "pytorch_script"],
     "zero": ["keras_hdf5"],
     "deepimagej": ["pytorch_script", "tensorflow_saved_model_bundle"],
     "fiji": ["tensorflow_saved_model_bundle"],


### PR DESCRIPTION
pytorch_state_dict allows more input shapes than other weight formats. We do not yet account for this limitation of `pytorch_script` and probably `ONNX`, thus many of the current models specify illegaly many input shapes.

For now let's at least prefer `pytorch_state_dict` weights for ilastik to reduce the frequency of this problem popping up.