### PR TITLE
Simplify source import

### DIFF
--- a/bioimageio/spec/shared/utils.py
+++ b/bioimageio/spec/shared/utils.py
@@ -182,7 +182,7 @@ class SourceNodeTransformer(NodeTransformer):
     @staticmethod
     def transform_ResolvedImportableSourceFile(node: ResolvedImportableSourceFile) -> nodes.ImportedSource:
         module_path = resolve_uri(node.source_file)
-        module_name = os.path.splitext(os.path.split(module_path)[1])[0]
+        module_name = f"module_from_source.{module_path.stem}"
         importlib_spec = importlib.util.spec_from_file_location(
             module_name, module_path
         )

--- a/bioimageio/spec/shared/utils.py
+++ b/bioimageio/spec/shared/utils.py
@@ -5,7 +5,6 @@ import os
 import pathlib
 import sys
 import typing
-import uuid
 import warnings
 from functools import singledispatch
 from types import ModuleType
@@ -182,8 +181,10 @@ class SourceNodeTransformer(NodeTransformer):
 
     @staticmethod
     def transform_ResolvedImportableSourceFile(node: ResolvedImportableSourceFile) -> nodes.ImportedSource:
+        module_path = resolve_uri(node.source_file)
+        module_name = os.path.splitext(os.path.split(module_path)[1])[0]
         importlib_spec = importlib.util.spec_from_file_location(
-            f"user_imports.{uuid.uuid4().hex}", resolve_uri(node.source_file)
+            module_name, module_path
         )
         assert importlib_spec is not None
         dep = importlib.util.module_from_spec(importlib_spec)


### PR DESCRIPTION
This PR simplifies the source import script.

@FynnBe I don't really understand the motivation for the old code and as far as I can see the complicated `f"user_imports{uuid}"` construction is not necessary. However, when using this it lead to some issues with the torchscript export. I don't have a good explanation for why this happens, maybe some nameclashes with `user_imports`?! In any case, the simplified code here fixes the issue.