### PR TITLE
Try interpreting lists of values in attachments as lists of URIs

### DIFF
--- a/bioimageio/spec/delegator.py
+++ b/bioimageio/spec/delegator.py
@@ -78,8 +78,8 @@ def serialize_raw_resource_description(raw_rd: Union[dict, RawResourceDescriptio
 
 def ensure_raw_resource_description(
     raw_rd: Union[str, dict, os.PathLike, URI, RawResourceDescription],
-    root_path: os.PathLike,
-    update_to_current_format: bool,
+    root_path: os.PathLike = pathlib.Path(),
+    update_to_current_format: bool = True,
 ) -> Tuple[RawResourceDescription, pathlib.Path]:
     if isinstance(raw_rd, raw_nodes.ResourceDescription) and not isinstance(raw_rd, URI):
         return raw_rd, pathlib.Path(root_path)

--- a/bioimageio/spec/model/v0_3/schema.py
+++ b/bioimageio/spec/model/v0_3/schema.py
@@ -286,9 +286,11 @@ class WeightsEntryBase(BioImageIOSchema):
         "who have converted the weights to this format.",
     )  # todo: copy root authors if missing
     attachments = fields.Dict(
+        fields.String,
+        fields.List(fields.Union([fields.URI(), fields.Raw()])),
         bioimageio_description="Dictionary of text keys and list values (that may contain any valid yaml) to "
         "additional, relevant files that are specific to the current weight format. A list of URIs can be listed under"
-        " the `files` key to included additional files for generating the model package."
+        " the `files` key to included additional files for generating the model package.",
     )
     parent = fields.String(
         bioimageio_description="The source weights used as input for converting the weights to this format. For "

--- a/bioimageio/spec/model/v0_3/utils.py
+++ b/bioimageio/spec/model/v0_3/utils.py
@@ -26,11 +26,13 @@ class IO(IO_Base):
     def load_raw_resource_description(cls, source: Union[os.PathLike, str, dict, URI_Node]) -> RawResourceDescription:
         raw_rd = super().load_raw_resource_description(source)
         assert isinstance(raw_rd, raw_nodes.Model)
-        doc = (raw_rd.config or {}).get("AUTO_CONVERTED_DOCUMENTATION_FILE_NAME")
+        doc = (raw_rd.config or {}).get(AUTO_CONVERTED_DOCUMENTATION_FILE_NAME)
         if doc is not None:
             # write doc to temporary path (we also do not know root_path here)
-            doc_path = BIOIMAGEIO_CACHE_PATH / "auto-convert" / hash(raw_rd) / AUTO_CONVERTED_DOCUMENTATION_FILE_NAME
-            doc_path.mkdir(parents=True, exists_ok=True)
+            doc_path = (
+                BIOIMAGEIO_CACHE_PATH / "auto-convert" / str(hash(cls.serialize_raw_resource_description(raw_rd)))
+            )
+            doc_path.mkdir(parents=True, exist_ok=True)
             doc_path = doc_path / AUTO_CONVERTED_DOCUMENTATION_FILE_NAME
             doc_path.write_text(doc)
             raw_rd.documentation = doc_path

--- a/bioimageio/spec/rdf/v0_2/schema.py
+++ b/bioimageio/spec/rdf/v0_2/schema.py
@@ -79,9 +79,11 @@ specified.
 
     attachments = fields.Dict(
         fields.String,
-        fields.List(fields.Raw),
-        bioimageio_maybe_required=True,
-        bioimageio_description=authors_bioimageio_description,
+        fields.List(
+            fields.Union([fields.URI(), fields.Raw()]),
+            bioimageio_maybe_required=True,
+            bioimageio_description=authors_bioimageio_description,
+        ),
     )
 
     authors = fields.List(


### PR DESCRIPTION
Fixes the problem that URIs in attachments:files are not deserialized as raw_nodes.URIs and thus not transformed correctly for remote sources by deserializing values in lists in attachments as URIs if possible.