### PR TITLE
Remove ruamel.yaml dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains specifications defined by the BioImage.IO community. Th
 
 
 All the BioImage.IO-compatible RDF must fulfill the following rules:
- * Must be a YAML file encoded as UTF-8;
+ * Must be a YAML file encoded as UTF-8; If yaml syntax version is not specified to be 1.1 in the first line by `% YAML 1.1` it must be equivalent in yaml 1.1 and yaml 1.2. For differences see https://yaml.readthedocs.io/en/latest/pyyaml.html#differences-with-pyyaml.
  * The RDF file extension must be `.yaml` (not `.yml`)
  * The RDF file can be saved in a folder (or virtual folder) or in a zip package, the following additional rules must apply:
    1. When stored in a local file system folder, github repo, zenodo deposition, blob storage virtual folder or similar kind, the RDF file name should match the pattern of `*.rdf.yaml`, for example `my-model.rdf.yaml`.

--- a/bioimageio/spec/shared/common.py
+++ b/bioimageio/spec/shared/common.py
@@ -7,49 +7,65 @@ import warnings
 from collections import UserDict
 from typing import Any, Dict, Generic, Optional
 
-import yaml as _yaml
 
 try:
     from typing import Literal, get_args, get_origin, Protocol
 except ImportError:
     from typing_extensions import Literal, get_args, get_origin, Protocol  # type: ignore
 
+import yaml as _yaml
 
-class yaml:
-    """ruamel.yaml replacement. This uses PyYAML's yaml 1.1 implementation with some manually added yaml 1.2 'fixes'"""
 
-    # floating point 'fix' for yaml 1.1 from https://stackoverflow.com/a/30462009
-    loader = _yaml.SafeLoader
-    loader.add_implicit_resolver(
-        "tag:yaml.org,2002:float",
-        re.compile(
-            """^(?:
-         [-+]?(?:[0-9][0-9_]*)\\.[0-9_]*(?:[eE][-+]?[0-9]+)?
-        |[-+]?(?:[0-9][0-9_]*)(?:[eE][-+]?[0-9]+)
-        |\\.[0-9_]+(?:[eE][-+][0-9]+)?
-        |[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\\.[0-9_]*
-        |[-+]?\\.(?:inf|Inf|INF)
-        |\\.(?:nan|NaN|NAN))$""",
-            re.X,
-        ),
-        list("-+0123456789."),
-    )
+class PyYAML:
+    """ruamel.yaml.YAML replacement. This uses PyYAML's yaml 1.1 implementation with some manually added yaml 1.2 'fixes'"""
 
-    @classmethod
-    def load(cls, stream):
+    def __init__(self, typ="safe"):
+        if typ != "safe":
+            raise NotImplementedError(typ)
+
+        # floating point 'fix' for yaml 1.1 from https://stackoverflow.com/a/30462009
+        self.loader = _yaml.SafeLoader
+        self.loader.add_implicit_resolver(
+            "tag:yaml.org,2002:float",
+            re.compile(
+                """^(?:
+             [-+]?(?:[0-9][0-9_]*)\\.[0-9_]*(?:[eE][-+]?[0-9]+)?
+            |[-+]?(?:[0-9][0-9_]*)(?:[eE][-+]?[0-9]+)
+            |\\.[0-9_]+(?:[eE][-+][0-9]+)?
+            |[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\\.[0-9_]*
+            |[-+]?\\.(?:inf|Inf|INF)
+            |\\.(?:nan|NaN|NAN))$""",
+                re.X,
+            ),
+            list("-+0123456789."),
+        )
+
+    def load(self, stream):
         if isinstance(stream, os.PathLike):
             with pathlib.Path(stream).open() as f:
-                return _yaml.load(f, Loader=cls.loader)
+                return _yaml.load(f, Loader=self.loader)
         else:
-            return _yaml.load(stream, Loader=cls.loader)
+            return _yaml.load(stream, Loader=self.loader)
 
-    @classmethod
-    def dump(cls, data, stream):
+    @staticmethod
+    def dump(data, stream):
         if isinstance(stream, os.PathLike):
             with pathlib.Path(stream).open("w") as f:
                 return _yaml.dump(data, f)
         else:
             return _yaml.dump(data, stream)
+
+
+pyyaml_yaml = PyYAML()
+
+try:
+    from ruamel.yaml import YAML
+except ImportError:
+    ruamel_yaml: Optional[YAML] = None
+    yaml = pyyaml_yaml
+else:
+    ruamel_yaml = YAML(typ="safe")
+    yaml = ruamel_yaml
 
 
 BIOIMAGEIO_CACHE_PATH = pathlib.Path(

--- a/bioimageio/spec/shared/common.py
+++ b/bioimageio/spec/shared/common.py
@@ -6,12 +6,37 @@ import warnings
 from collections import UserDict
 from typing import Any, Dict, Generic, Optional
 
-from ruamel.yaml import YAML
+import yaml as _yaml
 
 try:
     from typing import Literal, get_args, get_origin, Protocol
 except ImportError:
     from typing_extensions import Literal, get_args, get_origin, Protocol  # type: ignore
+
+
+class yaml:
+    """ruamel.yaml replacement"""
+
+    @classmethod
+    def load(cls, stream):
+        if isinstance(stream, os.PathLike):
+            with pathlib.Path(stream).open() as f:
+                return _yaml.load(f)
+        else:
+            return _yaml.load(stream)
+
+    @classmethod
+    def dump(cls, data, stream):
+        if isinstance(stream, os.PathLike):
+            with pathlib.Path(stream).open("w") as f:
+                return _yaml.dump(data, f)
+        else:
+            return _yaml.dump(data, stream)
+
+
+BIOIMAGEIO_CACHE_PATH = pathlib.Path(
+    os.getenv("BIOIMAGEIO_CACHE_PATH", pathlib.Path(tempfile.gettempdir()) / "bioimageio_cache")
+)
 
 
 def get_format_version_module(type_: str, format_version: str):
@@ -64,13 +89,6 @@ def get_args_flat(tp):
             flat_args.append(a)
 
     return tuple(flat_args)
-
-
-yaml = YAML(typ="safe")
-
-BIOIMAGEIO_CACHE_PATH = pathlib.Path(
-    os.getenv("BIOIMAGEIO_CACHE_PATH", pathlib.Path(tempfile.gettempdir()) / "bioimageio_cache")
-)
 
 
 class Singleton(type):

--- a/scripts/compare_yaml_syntax.py
+++ b/scripts/compare_yaml_syntax.py
@@ -1,0 +1,44 @@
+import json
+import sys
+from argparse import ArgumentParser
+from pathlib import Path
+
+from marshmallow_jsonschema import JSONSchema
+
+import bioimageio.spec
+
+from bioimageio.spec.shared.common import ruamel_yaml, pyyaml_yaml
+
+if ruamel_yaml is None:
+    raise RuntimeError("Cannot compare yaml syntax without the ruamel.yaml package")
+
+
+def parse_args():
+    p = ArgumentParser(
+        description="Check for differences between yaml 1.1 (using PyYAML) and yaml 1.2 syntax (using ruamel.yaml)."
+    )
+    p.add_argument("resource_description_path", type=Path)
+    args = p.parse_args()
+    return args
+
+
+def main(resource_description_path: Path):
+
+    pyyaml = pyyaml_yaml.load(resource_description_path)
+    assert isinstance(pyyaml, dict)
+    ruamel = ruamel_yaml.load(resource_description_path)
+    assert isinstance(ruamel, dict)
+
+    diff = {key: (value, ruamel[key]) for key, value in pyyaml.items() if value != ruamel[key]}
+    if diff:
+        print(f"Found differences between yaml syntax 1.1/1.2 for {resource_description_path}:")
+        print(diff)
+    else:
+        print(f"No differences found between yaml syntax 1.1/1.2 for {resource_description_path}:")
+
+    return len(diff)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    sys.exit(main(args.resource_description_path))

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "typing-extensions",
     ],
     entry_points={"console_scripts": ["bioimageio = bioimageio.spec.__main__:app"]},
-    extras_require={"test": ["pytest", "tox", "torch", "numpy", "mypy"], "dev": ["pre-commit"]},
+    extras_require={"test": ["pytest", "tox", "torch", "numpy", "mypy", "ruamel.yaml"], "dev": ["pre-commit"]},
     scripts=["scripts/generate_docs.py"],
     include_package_data=True,
     project_urls={  # Optional

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         "marshmallow-jsonschema",
         "marshmallow-union",
         "requests",
-        "ruamel.yaml",
         "typer",
         "typing-extensions",
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ from distutils.version import StrictVersion
 from pathlib import Path
 
 import pytest
-from ruamel.yaml import YAML
 
 from bioimageio import spec
 from bioimageio.spec import export_resource_package
@@ -13,8 +12,6 @@ try:
     from typing import get_args
 except ImportError:
     from typing_extensions import get_args  # type: ignore
-
-yaml = YAML(typ="safe")
 
 
 def get_unet2d_nuclei_broad_path(version: str):

--- a/tests/test_format_version_conversion.py
+++ b/tests/test_format_version_conversion.py
@@ -1,10 +1,7 @@
 from dataclasses import asdict
 
-from ruamel.yaml import YAML
-
 from bioimageio.spec.model import schema
-
-yaml = YAML(typ="safe")
+from bioimageio.spec.shared import yaml
 
 
 def test_model_format_version_conversion(unet2d_nuclei_broad_v0_1_0_path, unet2d_nuclei_broad_latest_path):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,11 +3,8 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from ruamel.yaml import YAML
 
 from bioimageio.spec.shared import nodes, raw_nodes, utils
-
-yaml = YAML(typ="safe")
 
 
 @dataclass

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,0 +1,29 @@
+"""
+Tests ruamel.yaml replacement.
+
+Why?
+PyYAML defaults to YAML 1.1 and does not yet support YAML 1.2 (which is the default for ruamel.yaml atm).
+For yaml 1.2 in PyYAML see https://github.com/yaml/pyyaml/issues/116 and  https://github.com/yaml/pyyaml/pull/512 .
+We want to ensure compatibility with yaml 1.2, while using yaml 1.1 for now to drop the ruamel.yaml dependency
+in order to more easily run with pyodide.
+For differences between yaml 1.1 and 1.2, see:
+https://yaml.readthedocs.io/en/latest/pyyaml.html#defaulting-to-yaml-1-2-support
+"""
+from ruamel.yaml import YAML
+
+
+ruamel_yaml = YAML(typ="safe")
+
+
+def test_unet2d_nuclei_broad_is_indifferent(unet2d_nuclei_broad_any_path):
+    from bioimageio.spec.shared import yaml  # PyYAML replacement for ruamel.yaml
+
+    expected = ruamel_yaml.load(unet2d_nuclei_broad_any_path)
+    actual = yaml.load(unet2d_nuclei_broad_any_path)
+
+    # ignore known difference:
+    # timestamp contains default utc timezone (tzinfo.utc) for ruamel.yaml, but not for PyYAML
+    expected.pop("timestamp")
+    actual.pop("timestamp")
+
+    assert expected == actual

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -9,6 +9,8 @@ in order to more easily run with pyodide.
 For differences between yaml 1.1 and 1.2, see:
 https://yaml.readthedocs.io/en/latest/pyyaml.html#defaulting-to-yaml-1-2-support
 """
+import json
+
 from ruamel.yaml import YAML
 
 
@@ -27,3 +29,16 @@ def test_unet2d_nuclei_broad_is_indifferent(unet2d_nuclei_broad_any_path):
     actual.pop("timestamp")
 
     assert expected == actual
+
+
+def test_flaoting_point_numbers():
+    from bioimageio.spec.shared import yaml  # PyYAML replacement for ruamel.yaml
+
+    expected = {"one": 1, "low": 0.000001}
+    data_str = json.dumps(expected)
+    actual_pyyaml = yaml.load(data_str)
+    assert expected == actual_pyyaml
+
+    # just to be sure we test ruamel.yaml as well...
+    actual_ruamel = ruamel_yaml.load(data_str)
+    assert expected == actual_ruamel

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -43,3 +43,11 @@ def test_flaoting_point_numbers_ruamel():
     data_str = json.dumps(expected)
     actual = ruamel_yaml.load(data_str)
     assert expected == actual
+
+
+def test_compare_script(unet2d_nuclei_broad_any_path):
+    from scripts.compare_yaml_syntax import main
+
+    diff = main(unet2d_nuclei_broad_any_path)
+
+    assert diff == 1  # ignore difference for timestamp

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -11,17 +11,12 @@ https://yaml.readthedocs.io/en/latest/pyyaml.html#defaulting-to-yaml-1-2-support
 """
 import json
 
-from ruamel.yaml import YAML
-
-
-ruamel_yaml = YAML(typ="safe")
-
 
 def test_unet2d_nuclei_broad_is_indifferent(unet2d_nuclei_broad_any_path):
-    from bioimageio.spec.shared import yaml  # PyYAML replacement for ruamel.yaml
+    from bioimageio.spec.shared.common import pyyaml_yaml, ruamel_yaml
 
     expected = ruamel_yaml.load(unet2d_nuclei_broad_any_path)
-    actual = yaml.load(unet2d_nuclei_broad_any_path)
+    actual = pyyaml_yaml.load(unet2d_nuclei_broad_any_path)
 
     # ignore known difference:
     # timestamp contains default utc timezone (tzinfo.utc) for ruamel.yaml, but not for PyYAML
@@ -31,14 +26,20 @@ def test_unet2d_nuclei_broad_is_indifferent(unet2d_nuclei_broad_any_path):
     assert expected == actual
 
 
-def test_flaoting_point_numbers():
-    from bioimageio.spec.shared import yaml  # PyYAML replacement for ruamel.yaml
+def test_flaoting_point_numbers_pyyaml():
+    from bioimageio.spec.shared.common import pyyaml_yaml, ruamel_yaml
 
     expected = {"one": 1, "low": 0.000001}
     data_str = json.dumps(expected)
-    actual_pyyaml = yaml.load(data_str)
-    assert expected == actual_pyyaml
+    actual = pyyaml_yaml.load(data_str)
+    assert expected == actual
 
-    # just to be sure we test ruamel.yaml as well...
-    actual_ruamel = ruamel_yaml.load(data_str)
-    assert expected == actual_ruamel
+
+# just to be sure we test ruamel.yaml as well...
+def test_flaoting_point_numbers_ruamel():
+    from bioimageio.spec.shared.common import ruamel_yaml
+
+    expected = {"one": 1, "low": 0.000001}
+    data_str = json.dumps(expected)
+    actual = ruamel_yaml.load(data_str)
+    assert expected == actual


### PR DESCRIPTION
ruamel.yaml is not supported by Pyodide, therefor we use PyYAML instead.

problem: PyYAML currently only supports yaml 1.1, whereas ruamel.yaml (what we used until now) defaults to yaml 1.2. 
Differences: https://yaml.readthedocs.io/en/latest/pyyaml.html#defaulting-to-yaml-1-2-support

The one difference that might be most relevant for us: "correct parsing of floating point scalars with exponentials" is added manually to the current ruamel.yaml replacement.
see https://github.com/yaml/pyyaml/issues/173 and https://stackoverflow.com/questions/30458977/yaml-loads-5e-6-as-string-and-not-a-number.

Also note that not all valid json is compatible with yaml 1.1 (but with yaml 1.2).

With this yaml 1.1/1.2 hybrid we should be good for now and can hopefully switch easily to the full yaml 1.2 in the future.