### PR TITLE
Be ok with absolute paths in UriNodeTransformer

### DIFF
--- a/bioimageio/spec/shared/utils.py
+++ b/bioimageio/spec/shared/utils.py
@@ -121,7 +121,6 @@ class UriNodeTransformer(NodeTransformer):
         return LocalImportableModule(**dataclasses.asdict(node), root_path=self.root_path)
 
     def _transform_Path(self, leaf: pathlib.Path):
-        assert not leaf.is_absolute()
         return self.root_path / leaf
 
     def transform_PosixPath(self, leaf: pathlib.PosixPath) -> pathlib.Path:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import pytest
@@ -105,3 +105,21 @@ def test_all_uris_available():
         "uri_exists": raw_nodes.URI(path="."),
     }
     assert not all_uris_available(not_available)
+
+
+def test_uri_node_transformer_is_ok_with_abs_path():
+    from bioimageio.spec.shared.utils import UriNodeTransformer
+
+    # note: the call of .absolute() is required to add the drive letter for windows paths, which are relative otherwise
+    tree = {"rel_path": Path("something/relative"), "abs_path": Path("/something/absolute").absolute()}
+    assert not tree["rel_path"].is_absolute()
+    assert tree["abs_path"].is_absolute()
+
+    root = Path("/root").absolute()
+    print(root)
+
+    tree = UriNodeTransformer(root_path=root).transform(tree)
+    assert tree["rel_path"].is_absolute()
+    assert tree["rel_path"] == Path("/root/something/relative").absolute()
+    assert tree["abs_path"].is_absolute()
+    assert tree["abs_path"] == Path("/something/absolute").absolute()


### PR DESCRIPTION
removes an overly careful assertion on relative paths.