### PR TITLE
ImplicitShape for inputs and outputs (part 1 in 0.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ or if the field `test_inputs` does not contain a list, it would print:
 
 
 ## Changelog
+ * **0.3.3**:
+    - Breaking changes that are fully auto-convertible
+      - `reference_input` for implicit output tensor shape was renamed to `reference_tensor`
  * **0.3.2**: 
     - Breaking changes
       - The RDF file name in a package should be `rdf.yaml` for all the RDF (not `model.yaml`);

--- a/bioimageio/spec/model/v0_1/raw_nodes.py
+++ b/bioimageio/spec/model/v0_1/raw_nodes.py
@@ -8,7 +8,7 @@ from typing import Any, ClassVar, Dict, List, Tuple, Union
 from marshmallow.utils import _Missing, missing
 
 from bioimageio.spec.rdf.v0_2.raw_nodes import CiteEntry
-from bioimageio.spec.shared.raw_nodes import Dependencies, ImplicitInputShape, ImplicitOutputShape, RawNode, URI
+from bioimageio.spec.shared.raw_nodes import Dependencies, ParametrizedInputShape, ImplicitOutputShape, RawNode, URI
 
 try:
     from typing import Literal
@@ -83,7 +83,7 @@ class Array(RawNode):
 
 @dataclass
 class InputArray(Array):
-    shape: Union[List[int], ImplicitInputShape] = missing
+    shape: Union[List[int], ParametrizedInputShape] = missing
 
 
 @dataclass

--- a/bioimageio/spec/model/v0_1/schema.py
+++ b/bioimageio/spec/model/v0_1/schema.py
@@ -1,7 +1,11 @@
 from marshmallow import ValidationError, validates_schema
 
 from bioimageio.spec.shared import fields
-from bioimageio.spec.shared.schema import ParametrizedInputShape, ImplicitOutputShape, SharedBioImageIOSchema
+from bioimageio.spec.shared.schema import (
+    ImplicitOutputShape as SharedImplicitOutputShape,
+    ParametrizedInputShape,
+    SharedBioImageIOSchema,
+)
 from . import raw_nodes
 
 
@@ -57,6 +61,12 @@ class Array(BioImageIOSchema):
 
 class InputArray(Array):
     shape = fields.Union([fields.ExplicitShape(), fields.Nested(ParametrizedInputShape)], required=True)
+
+
+class ImplicitOutputShape(SharedImplicitOutputShape):
+    reference_tensor = fields.String(
+        required=True, bioimageio_description="Name of the reference input tensor.", data_key="reference_input"
+    )
 
 
 class OutputArray(Array):

--- a/bioimageio/spec/model/v0_1/schema.py
+++ b/bioimageio/spec/model/v0_1/schema.py
@@ -1,7 +1,7 @@
 from marshmallow import ValidationError, validates_schema
 
 from bioimageio.spec.shared import fields
-from bioimageio.spec.shared.schema import ImplicitInputShape, ImplicitOutputShape, SharedBioImageIOSchema
+from bioimageio.spec.shared.schema import ParametrizedInputShape, ImplicitOutputShape, SharedBioImageIOSchema
 from . import raw_nodes
 
 
@@ -56,7 +56,7 @@ class Array(BioImageIOSchema):
 
 
 class InputArray(Array):
-    shape = fields.Union([fields.ExplicitShape(), fields.Nested(ImplicitInputShape)], required=True)
+    shape = fields.Union([fields.ExplicitShape(), fields.Nested(ParametrizedInputShape)], required=True)
 
 
 class OutputArray(Array):

--- a/bioimageio/spec/model/v0_3/converters.py
+++ b/bioimageio/spec/model/v0_3/converters.py
@@ -221,6 +221,16 @@ def convert_model_v0_3_1_to_v0_3_2(data: Dict[str, Any]) -> Dict[str, Any]:
     return data
 
 
+def convert_model_v0_3_2_to_v0_3_3(data: Dict[str, Any]) -> Dict[str, Any]:
+    data["format_version"] = "0.3.3"
+    for out in data["outputs"]:
+        shape = out["shape"]
+        if isinstance(shape, dict):
+            shape["reference_tensor"] = shape.pop("reference_input")
+
+    return data
+
+
 def maybe_convert(data: Dict[str, Any]) -> Dict[str, Any]:
     """auto converts model 'data' to newest format"""
     if data.get("format_version", "0.1.0") == "0.1.0":
@@ -232,6 +242,9 @@ def maybe_convert(data: Dict[str, Any]) -> Dict[str, Any]:
 
     if data["format_version"] == "0.3.1":
         data = convert_model_v0_3_1_to_v0_3_2(data)
+
+    if data["format_version"] == "0.3.2":
+        data = convert_model_v0_3_2_to_v0_3_3(data)
 
     # remove 'future' from config if no other than the used future entries exist
     config = data.get("config", {})

--- a/bioimageio/spec/model/v0_3/raw_nodes.py
+++ b/bioimageio/spec/model/v0_3/raw_nodes.py
@@ -9,7 +9,7 @@ from marshmallow.utils import _Missing
 
 from bioimageio.spec.rdf.v0_2.raw_nodes import Author, Badge, CiteEntry, Dependencies, RDF
 from bioimageio.spec.shared.raw_nodes import (
-    ImplicitInputShape,
+    ParametrizedInputShape,
     ImplicitOutputShape,
     ImportableModule,
     ImportableSourceFile,
@@ -36,7 +36,7 @@ WeightsFormat = Literal[
 # reassign to use imported classes
 Badge = Badge
 CiteEntry = CiteEntry
-ImplicitInputShape = ImplicitInputShape
+ParametrizedInputShape = ParametrizedInputShape
 ImplicitOutputShape = ImplicitOutputShape
 
 
@@ -63,7 +63,7 @@ class InputTensor(RawNode):
     name: str = missing
     data_type: str = missing
     axes: str = missing
-    shape: Union[List[int], ImplicitInputShape] = missing
+    shape: Union[List[int], ParametrizedInputShape] = missing
     preprocessing: Union[_Missing, List[Preprocessing]] = missing
     description: Union[_Missing, str] = missing
     data_range: Union[_Missing, Tuple[float, float]] = missing

--- a/bioimageio/spec/model/v0_3/raw_nodes.py
+++ b/bioimageio/spec/model/v0_3/raw_nodes.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
     from typing_extensions import Literal  # type: ignore
 
-FormatVersion = Literal["0.3.0", "0.3.1", "0.3.2"]  # newest format needs to be last (used in __init__.py)
+FormatVersion = Literal["0.3.0", "0.3.1", "0.3.2", "0.3.3"]  # newest format needs to be last (used in __init__.py)
 Framework = Literal["pytorch", "tensorflow"]
 Language = Literal["python", "java"]
 PostprocessingName = Literal[

--- a/bioimageio/spec/model/v0_3/schema.py
+++ b/bioimageio/spec/model/v0_3/schema.py
@@ -208,7 +208,7 @@ class InputTensor(Tensor):
         if bidx == -1:
             return
 
-        if isinstance(shape, raw_nodes.ImplicitInputShape):
+        if isinstance(shape, raw_nodes.ParametrizedInputShape):
             step = shape.step
             shape = shape.min
 

--- a/bioimageio/spec/shared/fields.py
+++ b/bioimageio/spec/shared/fields.py
@@ -260,7 +260,7 @@ class ImportableSource(String):
 
 class InputShape(Union):
     def __init__(self, **super_kwargs):
-        from .schema import ImplicitInputShape
+        from .schema import ParametrizedInputShape
 
         super().__init__(
             fields=[
@@ -268,7 +268,7 @@ class InputShape(Union):
                     bioimageio_description="Exact shape with same length as `axes`, e.g. `shape: [1, 512, 512, 1]`"
                 ),
                 Nested(
-                    ImplicitInputShape,
+                    ParametrizedInputShape,
                     bioimageio_description="A sequence of valid shapes given by `shape = min + k * step for k in {0, 1, ...}`.",
                 ),
             ],

--- a/bioimageio/spec/shared/raw_nodes.py
+++ b/bioimageio/spec/shared/raw_nodes.py
@@ -136,7 +136,7 @@ class ParametrizedInputShape(RawNode):
 
 @dataclass
 class ImplicitOutputShape(RawNode):
-    reference_input: str = missing
+    reference_tensor: str = missing
     scale: List[float] = missing
     offset: List[int] = missing
 

--- a/bioimageio/spec/shared/raw_nodes.py
+++ b/bioimageio/spec/shared/raw_nodes.py
@@ -126,7 +126,7 @@ class Dependencies(RawNode):
 
 
 @dataclass
-class ImplicitInputShape(RawNode):
+class ParametrizedInputShape(RawNode):
     min: List[float] = missing
     step: List[float] = missing
 

--- a/bioimageio/spec/shared/schema.py
+++ b/bioimageio/spec/shared/schema.py
@@ -60,7 +60,7 @@ class ParametrizedInputShape(SharedBioImageIOSchema):
 
 
 class ImplicitOutputShape(SharedBioImageIOSchema):
-    reference_input = fields.String(required=True, bioimageio_description="Name of the reference input tensor.")
+    reference_tensor = fields.String(required=True, bioimageio_description="Name of the reference tensor.")
     scale = fields.List(
         fields.Float, required=True, bioimageio_description="'output_pix/input_pix' for each dimension."
     )

--- a/bioimageio/spec/shared/schema.py
+++ b/bioimageio/spec/shared/schema.py
@@ -40,7 +40,7 @@ class Dependencies(SharedBioImageIOSchema):
     )
 
 
-class ImplicitInputShape(SharedBioImageIOSchema):
+class ParametrizedInputShape(SharedBioImageIOSchema):
     min = fields.List(
         fields.Integer, required=True, bioimageio_description="The minimum input shape with same length as `axes`"
     )

--- a/example_specs/models/unet2d_nuclei_broad/rdf_v0_3_2.yaml
+++ b/example_specs/models/unet2d_nuclei_broad/rdf_v0_3_2.yaml
@@ -1,5 +1,5 @@
 # TODO physical scale of the data
-format_version: 0.3.3
+format_version: 0.3.2
 
 name: UNet 2D Nuclei Broad
 description: A 2d U-Net trained on the nuclei broad dataset.
@@ -48,7 +48,7 @@ outputs:
     data_range: [-.inf, .inf]
     halo: [0, 0, 32, 32]
     shape:
-      reference_tensor: raw
+      reference_input: raw
       scale: [1.0, 1.0, 1.0, 1.0]
       offset: [0, 0, 0, 0]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ def unet2d_nuclei_broad_base_path():
 
 
 def get_unet2d_nuclei_broad(unet2d_nuclei_broad_base_path, request) -> dict:
-    if request.param == "v0_3_2":
+    if request.param == "v0_3_3":
         v = ""
     else:
         v = f"_{request.param}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,22 +21,22 @@ def get_unet2d_nuclei_broad(unet2d_nuclei_broad_base_path, request) -> dict:
     return yaml.load(path)
 
 
-@pytest.fixture(params=["v0_1_0", "v0_3_0", "v0_3_1", "v0_3_2"])
+@pytest.fixture(params=["v0_1_0", "v0_3_0", "v0_3_1", "v0_3_2", "v0_3_3"])
 def unet2d_nuclei_broad_any(unet2d_nuclei_broad_base_path, request):
     yield get_unet2d_nuclei_broad(unet2d_nuclei_broad_base_path, request)
 
 
-@pytest.fixture(params=["v0_1_0", "v0_3_0", "v0_3_1"])
+@pytest.fixture(params=["v0_1_0", "v0_3_0", "v0_3_1", "v0_3_2"])
 def unet2d_nuclei_broad_before_latest(unet2d_nuclei_broad_base_path, request):
     yield get_unet2d_nuclei_broad(unet2d_nuclei_broad_base_path, request)
 
 
-@pytest.fixture(params=["v0_3_2"])
+@pytest.fixture(params=["v0_3_3"])
 def unet2d_nuclei_broad_latest(unet2d_nuclei_broad_base_path, request):
     yield get_unet2d_nuclei_broad(unet2d_nuclei_broad_base_path, request)
 
 
-@pytest.fixture(params=["v0_1_0", "v0_3_2"])
+@pytest.fixture(params=["v0_1_0", "v0_3_3"])
 def unet2d_nuclei_broad_any_minor(unet2d_nuclei_broad_base_path, request):
     yield get_unet2d_nuclei_broad(unet2d_nuclei_broad_base_path, request)
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -77,7 +77,7 @@ class TestShape:
 
     def test_min_step_input_shape(self):
         data = {"min": [1, 2, 3], "step": [0, 1, 3]}
-        expected = raw_nodes.ImplicitInputShape(**data)
+        expected = raw_nodes.ParametrizedInputShape(**data)
         actual = fields.InputShape().deserialize(data)
         assert expected == actual
 


### PR DESCRIPTION
This PR changes implements the first set of changes discussed in #234 

also it:
- rename `ImplicitInputShape` to `ParametrizedInputShape` to avoid confusion