### PR TITLE
support loading yaml from str

### DIFF
--- a/bioimageio/spec/commands.py
+++ b/bioimageio/spec/commands.py
@@ -36,11 +36,9 @@ def validate(
 
             if is_path:
                 rdf_source = pathlib.Path(rdf_source)
-            else:
-                raise RuntimeError(f"Could not retrieve {rdf_source}")
 
         if yaml is None:
-            raise RuntimeError("Cannot validate from file without ruamel.yaml dependency!")
+            raise RuntimeError("Cannot validate from file or yaml string without ruamel.yaml dependency!")
 
         rdf_source = yaml.load(rdf_source)
 


### PR DESCRIPTION
#242 got me looking into validating a yaml string, which we do not currently support. This PR changes that.

Until now, validate excepts a string, but only tries to interpret it as a URL (if it starts with 'https' or as a path (if that path exists)). This PR tries to load the string with ruamel.yaml if interpretation as URL and path failed.