### PR TITLE
remove SpecURI from model v0.1

### DIFF
--- a/bioimageio/spec/model/v0_1/schema.py
+++ b/bioimageio/spec/model/v0_1/schema.py
@@ -46,7 +46,7 @@ class BaseSpec(BioImageIOSchema):
 
 
 class SpecWithKwargs(BioImageIOSchema):
-    spec: fields.SpecURI
+    spec = fields.URI()
     kwargs = fields.Dict()
 
 
@@ -81,7 +81,7 @@ class TransformationSpec(BaseSpec):
 
 
 class Transformation(SpecWithKwargs):
-    spec = fields.SpecURI(TransformationSpec, required=True)
+    spec = fields.URI(required=True)
 
 
 class Weights(BioImageIOSchema):
@@ -102,7 +102,7 @@ class ReaderSpec(BaseSpec):
 
 
 class Reader(SpecWithKwargs):
-    spec = fields.SpecURI(ReaderSpec)
+    spec = fields.URI()
     transformations = fields.List(fields.Nested(Transformation))
 
 
@@ -112,7 +112,7 @@ class SamplerSpec(BaseSpec):
 
 
 class Sampler(SpecWithKwargs):
-    spec = fields.SpecURI(SamplerSpec)
+    spec = fields.URI()
     readers = fields.List(fields.Nested(Reader, required=True), required=True)
 
 

--- a/bioimageio/spec/model/v0_3/schema.py
+++ b/bioimageio/spec/model/v0_3/schema.py
@@ -36,7 +36,7 @@ class RunMode(BioImageIOSchema):
 
 
 class SpecWithKwargs(BioImageIOSchema):
-    spec: fields.SpecURI
+    spec = fields.URI()
     kwargs = fields.Kwargs()
 
 

--- a/bioimageio/spec/shared/fields.py
+++ b/bioimageio/spec/shared/fields.py
@@ -394,29 +394,6 @@ class SHA256(String):
         return value_str
 
 
-class SpecURI(Nested):
-    def _deserialize(self, value, attr, data, **kwargs):
-        uri = urlparse(value)
-
-        if uri.query:
-            raise ValidationError(f"Invalid URI: {value}. We do not support query: {uri.query}")
-        if uri.fragment:
-            raise ValidationError(f"Invalid URI: {value}. We do not support fragment: {uri.fragment}")
-        if uri.params:
-            raise ValidationError(f"Invalid URI: {value}. We do not support params: {uri.params}")
-
-        if uri.scheme == "file":
-            # account for leading '/' for windows paths, e.g. '/C:/folder'
-            # see https://stackoverflow.com/questions/43911052/urlparse-on-a-windows-file-scheme-uri-leaves-extra-slash-at-start
-            path = url2pathname(uri.path)
-        else:
-            path = uri.path
-
-        return raw_nodes.SpecURI(
-            spec_schema=self.schema, scheme=uri.scheme, authority=uri.netloc, path=path, query="", fragment=""
-        )
-
-
 class StrictVersion(String):
     def _deserialize(
         self,


### PR DESCRIPTION
The spec url functionality for nested RDFs in model RDF 0.1 was never fully supported. This PR turns those special URIs into regular `field.URI`s