### PR TITLE
force encoding to utf-8

### DIFF
--- a/bioimageio/spec/VERSION
+++ b/bioimageio/spec/VERSION
@@ -1,3 +1,3 @@
 {
-    "version": "0.3.3post1"
+    "version": "0.3.3post2"
 }

--- a/bioimageio/spec/shared/__init__.py
+++ b/bioimageio/spec/shared/__init__.py
@@ -7,7 +7,7 @@ from . import fields, raw_nodes, schema
 from .common import get_args, yaml  # noqa
 
 _license_file = Path(__file__).parent.parent / "static" / "licenses.json"
-_license_data = json.loads(_license_file.read_text())
+_license_data = json.loads(_license_file.read_text(encoding="utf-8"))
 
 LICENSES = {x["licenseId"]: x for x in _license_data["licenses"]}
 LICENSE_DATA_VERSION = _license_data["licenseListVersion"]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_namespace_packages, setup
 ROOT_DIR = Path(__file__).parent.resolve()
 long_description = (ROOT_DIR / "README.md").read_text(encoding="utf-8")
 VERSION_FILE = ROOT_DIR / "bioimageio" / "spec" / "VERSION"
-VERSION = json.loads(VERSION_FILE.read_text())["version"]
+VERSION = json.loads(VERSION_FILE.read_text(encoding="utf-8"))["version"]
 
 
 setup(


### PR DESCRIPTION
read_text takes the default locale... Now fun fact - when packaging ilastik for OSX and starting via double click, this seems to default to ascii