### PR TITLE
improve summary output of validate

### DIFF
--- a/bioimageio/spec/__main__.py
+++ b/bioimageio/spec/__main__.py
@@ -19,15 +19,18 @@ def validate(
     update_format_inner: bool = typer.Option(
         None, help="For collection RDFs only. Defaults to value of 'update-format'."
     ),
-    verbose: bool = typer.Option(False, help="show traceback of exceptions"),
+    verbose: bool = typer.Option(False, help="show traceback of unexpected (no ValidationError) exceptions"),
 ) -> int:
-    errors = commands.validate(rdf_source, update_format, update_format_inner, verbose)
-    if errors:
-        print(f"Errors for {rdf_source}")
-        pprint(errors)
+    summary = commands.validate(rdf_source, update_format, update_format_inner)
+    if summary["error"] is not None:
+        print(f"Errors for {summary['name']}")
+        pprint(summary["errors"])
+        if verbose:
+            print("traceback:")
+            pprint(summary["traceback"])
         return 1
     else:
-        print(f"No validation errors for {rdf_source}")
+        print(f"No validation errors for {summary['name']}")
         return 0
 
 

--- a/bioimageio/spec/commands.py
+++ b/bioimageio/spec/commands.py
@@ -1,53 +1,74 @@
 import os
 import traceback
-from typing import Dict, IO, List, Sequence, Union
+import warnings
+from typing import Dict, IO, Optional, Union
 
 from marshmallow import ValidationError
 
 from .io_ import load_raw_resource_description, resolve_rdf_source
+
+KNOWN_COLLECTION_CATEGORIES = ("application", "collection", "dataset", "model", "notebook")
 
 
 def validate(
     rdf_source: Union[dict, os.PathLike, IO, str, bytes],
     update_format: bool = False,
     update_format_inner: bool = None,
-    verbose: bool = False,
-) -> Dict[str, Union[str, list, dict]]:
-    """Validate a BioImage.IO Resource Description File (RDF)."""
+    verbose: bool = "deprecated",  # type: ignore
+) -> dict:
+    """Validate a BioImage.IO Resource Description File (RDF).
+
+    Args:
+        rdf_source: resource description as path, url or bytes of an RDF or packaged resource, or as yaml string or dict
+        update_format: weather or not to apply auto-conversion to the latest format version before validation
+        update_format_inner: (applicable to `collections` resources only) `update_format` for nested resources
+        verbose: deprecated
+
+    Returns:
+        A summary dict with "error", "traceback" and "nested_errors" keys.
+    """
+    if verbose != "deprecated":
+        warnings.warn("'verbose' flag is deprecated")
+
     if update_format_inner is None:
         update_format_inner = update_format
 
     rdf_source, source_name, root = resolve_rdf_source(rdf_source)
     assert isinstance(rdf_source, dict)
+
+    error = None
+    tb = None
+    raw_rd = None
     try:
         raw_rd = load_raw_resource_description(rdf_source, update_to_current_format=update_format)
     except ValidationError as e:
-        return {source_name: e.normalized_messages()}
+        error = e.normalized_messages()
     except Exception as e:
-        if verbose:
-            msg: Union[str, Dict[str, Union[str, Sequence[str]]]] = {
-                "error": str(e),
-                "traceback": traceback.format_tb(e.__traceback__),
-            }
-        else:
-            msg = str(e)
+        error = (str(e),)
+        tb = traceback.format_tb(e.__traceback__)
 
-        return {source_name: msg}
-
-    collection_errors: List[Union[str, dict]] = []
-    if raw_rd.type == "collection":
-        for inner_category in ["application", "collection", "dataset", "model", "notebook"]:
+    nested_errors: Dict[str, list] = {}
+    if raw_rd is not None and raw_rd.type == "collection":
+        for inner_category in KNOWN_COLLECTION_CATEGORIES:
             for inner in getattr(raw_rd, inner_category) or []:
                 try:
                     inner_source = inner.source
                 except Exception as e:
-                    collection_errors.append(str(e))
+                    inner_summary = {"error": str(e)}
                 else:
-                    inner_errors = validate(inner_source, update_format_inner, update_format_inner, verbose)
-                    if inner_errors:
-                        collection_errors.append(inner_errors)
+                    inner_summary = validate(inner_source, update_format_inner, update_format_inner)
 
-    if collection_errors:
-        return {source_name: collection_errors}
-    else:
-        return {}
+                if inner_summary["error"] is not None:
+                    assert nested_errors is not None
+                    nested_errors[inner_category] = nested_errors.get(inner_category, []) + [inner_summary]
+
+        if nested_errors:
+            error = f"Errors in collections of {list(nested_errors)}"
+
+    return {
+        "name": source_name if raw_rd is None else raw_rd.name,
+        "source_name": source_name,
+        "error": error,
+        "traceback": tb,
+        "nested_errors": nested_errors,
+    }

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -6,8 +6,8 @@ from io import BytesIO, StringIO
 def test_validate_model_as_dict(unet2d_nuclei_broad_any):
     from bioimageio.spec.commands import validate
 
-    assert not validate(unet2d_nuclei_broad_any, update_format=True, update_format_inner=False)
-    assert not validate(unet2d_nuclei_broad_any, update_format=False, update_format_inner=False)
+    assert not validate(unet2d_nuclei_broad_any, update_format=True, update_format_inner=False)["error"]
+    assert not validate(unet2d_nuclei_broad_any, update_format=False, update_format_inner=False)["error"]
 
 
 def test_validate_model_as_url():
@@ -17,19 +17,19 @@ def test_validate_model_as_url():
         "https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/models/unet2d_nuclei_broad/rdf.yaml",
         update_format=True,
         update_format_inner=False,
-    )
+    )["error"]
     assert not validate(
         "https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/models/unet2d_nuclei_broad/rdf.yaml",
         update_format=False,
         update_format_inner=False,
-    )
+    )["error"]
 
 
 def test_validate_model_as_zenodo_sandbox_doi():
     from bioimageio.spec.commands import validate
 
-    assert not validate("10.5072/zenodo.886788", update_format=True, update_format_inner=False)
-    assert not validate("10.5072/zenodo.886788", update_format=False, update_format_inner=False)
+    assert not validate("10.5072/zenodo.886788", update_format=True, update_format_inner=False)["error"]
+    assert not validate("10.5072/zenodo.886788", update_format=False, update_format_inner=False)["error"]
 
 
 # todo: add test with real doi
@@ -40,9 +40,9 @@ def test_validate_model_as_bytes_io(unet2d_nuclei_broad_latest_path):
 
     data = BytesIO(unet2d_nuclei_broad_latest_path.read_bytes())
     data.seek(0)
-    assert not validate(data, update_format=True, update_format_inner=False)
+    assert not validate(data, update_format=True, update_format_inner=False)["error"]
     data.seek(0)
-    assert not validate(data, update_format=False, update_format_inner=False)
+    assert not validate(data, update_format=False, update_format_inner=False)["error"]
 
 
 def test_validate_model_as_string_io(unet2d_nuclei_broad_latest_path):
@@ -50,25 +50,25 @@ def test_validate_model_as_string_io(unet2d_nuclei_broad_latest_path):
 
     data = StringIO(unet2d_nuclei_broad_latest_path.read_text())
     data.seek(0)
-    assert not validate(data, update_format=True, update_format_inner=False)
+    assert not validate(data, update_format=True, update_format_inner=False)["error"]
     data.seek(0)
-    assert not validate(data, update_format=False, update_format_inner=False)
+    assert not validate(data, update_format=False, update_format_inner=False)["error"]
 
 
 def test_validate_model_as_bytes(unet2d_nuclei_broad_latest_path):
     from bioimageio.spec.commands import validate
 
     data = unet2d_nuclei_broad_latest_path.read_bytes()
-    assert not validate(data, update_format=True, update_format_inner=False)
-    assert not validate(data, update_format=False, update_format_inner=False)
+    assert not validate(data, update_format=True, update_format_inner=False)["error"]
+    assert not validate(data, update_format=False, update_format_inner=False)["error"]
 
 
 def test_validate_model_as_string(unet2d_nuclei_broad_latest_path):
     from bioimageio.spec.commands import validate
 
     data = unet2d_nuclei_broad_latest_path.read_text()
-    assert not validate(data, update_format=True, update_format_inner=False)
-    assert not validate(data, update_format=False, update_format_inner=False)
+    assert not validate(data, update_format=True, update_format_inner=False)["error"]
+    assert not validate(data, update_format=False, update_format_inner=False)["error"]
 
 
 def test_validate_model_package_as_bytes(unet2d_nuclei_broad_latest_path):
@@ -79,9 +79,9 @@ def test_validate_model_package_as_bytes(unet2d_nuclei_broad_latest_path):
         zf.write(unet2d_nuclei_broad_latest_path, "rdf.yaml")
 
     data.seek(0)
-    assert not validate(data, update_format=True, update_format_inner=False)
+    assert not validate(data, update_format=True, update_format_inner=False)["error"]
     data.seek(0)
-    assert not validate(data, update_format=False, update_format_inner=False)
+    assert not validate(data, update_format=False, update_format_inner=False)["error"]
 
 
 def test_validate_model_package_on_disk(unet2d_nuclei_broad_latest_path, tmpdir):
@@ -91,8 +91,8 @@ def test_validate_model_package_on_disk(unet2d_nuclei_broad_latest_path, tmpdir)
     with zipfile.ZipFile(zf_path, "w") as zf:
         zf.write(unet2d_nuclei_broad_latest_path, "rdf.yaml")
 
-    assert not validate(zf_path, update_format=True, update_format_inner=False)
-    assert not validate(zf_path, update_format=False, update_format_inner=False)
+    assert not validate(zf_path, update_format=True, update_format_inner=False)["error"]
+    assert not validate(zf_path, update_format=False, update_format_inner=False)["error"]
 
 
 def test_validate_invalid_model(unet2d_nuclei_broad_latest):
@@ -100,5 +100,5 @@ def test_validate_invalid_model(unet2d_nuclei_broad_latest):
 
     data = copy(unet2d_nuclei_broad_latest)
     del data["test_inputs"]  # invalidate data
-    assert validate(data, update_format=True, update_format_inner=False)
-    assert validate(data, update_format=False, update_format_inner=False)
+    assert validate(data, update_format=True, update_format_inner=False)["error"]
+    assert validate(data, update_format=False, update_format_inner=False)["error"]


### PR DESCRIPTION
looking at how the `validate` command is now used on model upload, I thought it could be enhanced by making it a summary. 

The summary is a dict of the form:
```python
{
        "name": source_name if raw_rd is None else raw_rd.name,
        "source_name": source_name,
        "error": error,
        "traceback": tb,
        "nested_errors": nested_errors,
    }
```

Pros:
 - more explicit information
 - output just looks better
 - easy extension with 'warnings' key (wherever that is implemented)

Cons:
 - change from before: The returned dictionary now will never be empty. Need to check if the 'error' key is `None` 
 

 (note: this does not change the error message for the Union field)