### PR TITLE
Better Union field error message

### DIFF
--- a/bioimageio/spec/shared/fields.py
+++ b/bioimageio/spec/shared/fields.py
@@ -171,13 +171,8 @@ class Union(DocumentedField, marshmallow_union.Union):
         try:
             return super()._deserialize(value, attr=attr, data=data, **kwargs)
         except ValidationError as e:
-            errors = e.messages
-            n_errors_short = min([len(er) for er in errors])
-            short_errors = [er for er in errors if len(er) == n_errors_short]
-            long_errors = [er for er in errors if len(er) != n_errors_short]
-            messages = (
-                ["Errors in all options for this field. Fix any of the following errors:"] + short_errors + long_errors
-            )
+            errors = sorted(e.messages, key=lambda msg: len(msg))
+            messages = ["Errors in all options for this field. Fix any of the following errors:"] + errors
             raise ValidationError(message=messages, field_name=attr) from e
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -102,3 +102,13 @@ class TestURI:
         uri_node = fields.URI().deserialize(uri_raw)
 
         assert uri_raw == str(uri_node)
+
+
+class TestUnion:
+    def test_error_messages(self):
+        union = fields.Union([fields.String(), fields.Number()])
+        try:
+            union.deserialize([1])
+        except ValidationError as e:
+            assert isinstance(e, ValidationError)
+            assert len(e.messages) == 3, e.messages


### PR DESCRIPTION
This PR adds an explanation to the multiple error lines resulting from a failed Union field:
The new output has the form:
 - 'Errors in all options. Fix any of the following errors:', 
 - <error for option 1>
 - <error for option 2> 
 
The individual errors (which are lists themselves) are sorted by length to more easily find the most straightforward fix.