### PR TITLE
Add --version option to CLI

### DIFF
--- a/bioimageio/spec/__main__.py
+++ b/bioimageio/spec/__main__.py
@@ -2,11 +2,17 @@ from pprint import pprint
 
 import typer
 
-from bioimageio.spec import __version__, commands
+from bioimageio.spec import __version__, commands, model, rdf
 
-help_version = f"bioimageio.spec package version {__version__}"
+help_version = (
+    f"bioimageio.spec {__version__}"
+    "\nimplementing:"
+    f"\n\tgeneral RDF {rdf.format_version}"
+    f"\n\tmodel RDF {model.format_version}"
+)
+# prevent rewrapping with \b\n: https://click.palletsprojects.com/en/7.x/documentation/#preventing-rewrapping
 app = typer.Typer(
-    help=help_version,
+    help="\b\n" + help_version,
     context_settings={"help_option_names": ["-h", "--help", "--version"]},  # make --version display help with version
 )  # https://typer.tiangolo.com/
 
@@ -40,11 +46,11 @@ def validate(
 
 validate.__doc__ = commands.validate.__doc__
 
-# single command requires additional dummy callback
+# note: single command requires additional (dummy) callback
 # see: https://typer.tiangolo.com/tutorial/commands/one-or-multiple/#one-command-and-one-callback
 @app.callback()
 def callback():
-    typer.echo(help_version)  # use this callback to print out version
+    typer.echo(help_version)
 
 
 if __name__ == "__main__":

--- a/bioimageio/spec/__main__.py
+++ b/bioimageio/spec/__main__.py
@@ -4,7 +4,11 @@ import typer
 
 from bioimageio.spec import __version__, commands
 
-app = typer.Typer()  # https://typer.tiangolo.com/
+help_version = f"bioimageio.spec package version {__version__}"
+app = typer.Typer(
+    help=help_version,
+    context_settings={"help_option_names": ["-h", "--help", "--version"]},  # make --version display help with version
+)  # https://typer.tiangolo.com/
 
 
 @app.command()
@@ -40,9 +44,8 @@ validate.__doc__ = commands.validate.__doc__
 # see: https://typer.tiangolo.com/tutorial/commands/one-or-multiple/#one-command-and-one-callback
 @app.callback()
 def callback():
-    pass
+    typer.echo(help_version)  # use this callback to print out version
 
 
 if __name__ == "__main__":
-    print(f"bioimageio.spec package version {__version__}")
     app()


### PR DESCRIPTION
displays help on receiving `--version` argument

a separate `--version` option is not straight forward to implement with typer as it complains about a missing command. But making the `--version` option available without command leads to the CLI not complaining about a missing command even without the `--version` option. It is just overall simpler to add it as a help alias, especially because the version is very relevent for the help as well.

To make the verion/help even more useful this PR also adds the format versions of the implemented RDFs (general RDF and model RDF) to the help/version string:

```
Usage: bioimageio [OPTIONS] COMMAND [ARGS]...
```
new help/version string from this PR:
```
  bioimageio.spec 0.3.3post6
  implementing:
          general RDF 0.2.0
          model RDF 0.3.3
```
```
Options:
  --install-completion   Install completion for the current shell.
  --show-completion      Show completion for the current shell, to copy it or
                         customize the installation.

  -h, --version, --help  Show this message and exit.

Commands:
  validate  Validate a BioImage.IO Resource Description File (RDF).

```