### PR TITLE
Generate pre-/postprocessing docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.7
@@ -87,8 +86,14 @@ jobs:
       run: python scripts/generate_json_specs.py
     - name: Check weights format overview
       run: python scripts/generate_weights_formats_overview.py generate
-    - name: Deploy Docs and Schema 🚀
+    - name: Get branch name to deploy to
+      id: get_branch
+      shell: bash
+      run: |
+        if [[ -n '${{ github.event.pull_request.head.ref }}' ]]; then branch=gh-pages-${{ github.event.pull_request.head.ref }}; else branch=gh-pages; fi
+        echo "::set-output name=branch::$branch"
+    - name: Deploy to ${{ steps.get_branch.outputs.branch }} 🚀
       uses: JamesIves/github-pages-deploy-action@4.1.4
       with:
-        branch: gh-pages
+        branch: ${{ steps.get_branch.outputs.branch }}
         folder: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,8 @@ jobs:
         pip install .
     - name: Generate Docs
       run: python scripts/generate_docs.py
+    - name: Generate Pre-/Postprocessing Docs
+      run: python scripts/generate_processing_docs.py
     - name: Generate JSON Schema
       run: python scripts/generate_json_specs.py
     - name: Check weights format overview

--- a/.github/workflows/post-merge-cleanup.yaml
+++ b/.github/workflows/post-merge-cleanup.yaml
@@ -1,0 +1,22 @@
+name: Delete PR branch and gh-pages preview after PR merge
+
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  delete_PR_branch:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: delete PR branch ${{ github.event.pull_request.head.ref }}
+        run: git push origin --delete ${{ github.event.pull_request.head.ref }}
+
+  delete_gh-pages_preview:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: delete gh-pages preview branch gh-pages-${{ github.event.pull_request.head.ref }}
+        run: git push origin --delete gh-pages-${{ github.event.pull_request.head.ref }}

--- a/bioimageio/spec/model/v0_3/schema.py
+++ b/bioimageio/spec/model/v0_3/schema.py
@@ -196,7 +196,7 @@ class Preprocessing(Processing):
     kwargs = fields.Kwargs()
 
     class ScaleRange(SharedProcessingSchema):
-        bioimageio_description = "Scale with percentiles"
+        bioimageio_description = "Scale with percentiles."
         mode = fields.ProcMode(required=True, valid_modes=("per_dataset", "per_sample"))
         axes = fields.Axes(
             required=True,
@@ -240,17 +240,17 @@ class Postprocessing(Processing):
         reference_tensor = fields.String(
             required=False,
             validate=field_validators.Predicate("isidentifier"),
-            bioimageio_description="tensor name to compute the percentiles from. Default: The tensor itself. "
+            bioimageio_description="Tensor name to compute the percentiles from. Default: The tensor itself. "
             "If mode==per_dataset this needs to be the name of an input tensor.",
         )
 
     class ScaleMeanVariance(SharedProcessingSchema):
-        bioimageio_description = "scale the tensor s.t. its mean and variance match a reference tensor"
+        bioimageio_description = "Scale the tensor s.t. its mean and variance match a reference tensor."
         mode = fields.ProcMode(required=True, valid_modes=("per_dataset", "per_sample"))
         reference_tensor = fields.String(
             required=True,
             validate=field_validators.Predicate("isidentifier"),
-            bioimageio_description="name of tensor to match",
+            bioimageio_description="Name of tensor to match.",
         )
 
 

--- a/bioimageio/spec/model/v0_3/schema.py
+++ b/bioimageio/spec/model/v0_3/schema.py
@@ -89,20 +89,31 @@ class Tensor(BioImageIOSchema):
 
 class Processing(BioImageIOSchema):
     class Binarize(SharedProcessingSchema):
-        bioimageio_description = ""
-        threshold = fields.Float(required=True)
+        bioimageio_description = (
+            "Binarize the tensor with a fixed threshold, values above the threshold will be set to one, values below "
+            "the threshold to zero."
+        )
+        threshold = fields.Float(required=True, bioimageio_description="The fixed threshold")
 
     class Clip(SharedProcessingSchema):
         bioimageio_description = "Set tensor values below min to min and above max to max."
-        min = fields.Float(required=True)
-        max = fields.Float(required=True)
+        min = fields.Float(required=True, bioimageio_description="minimum value for clipping")
+        max = fields.Float(required=True, bioimageio_description="maximum value for clipping")
 
     class ScaleLinear(SharedProcessingSchema):
         bioimageio_description = "Fixed linear scaling."
-        axes = fields.Axes(required=True, valid_axes="czyx")
-        gain = fields.Array(fields.Float(), missing=fields.Float(missing=1.0))  # todo: check if gain match input axes
+        axes = fields.Axes(
+            required=True,
+            valid_axes="czyx",
+            bioimageio_description="The subset of axes to scale jointly. "
+            "For example xy to scale the two image axes for 2d data jointly. "
+            "The batch axis (b) is not valid here.",
+        )
+        gain = fields.Array(
+            fields.Float(), missing=fields.Float(missing=1.0), bioimageio_description="multiplicative factor"
+        )  # todo: check if gain match input axes
         offset = fields.Array(
-            fields.Float(), missing=fields.Float(missing=0.0)
+            fields.Float(), missing=fields.Float(missing=0.0), bioimageio_description="additive term"
         )  # todo: check if offset match input axes
 
         @validates_schema
@@ -139,16 +150,33 @@ class Processing(BioImageIOSchema):
     class ZeroMeanUnitVariance(SharedProcessingSchema):
         bioimageio_description = "Subtract mean and divide by variance."
         mode = fields.ProcMode(required=True)
-        axes = fields.Axes(required=True, valid_axes="czyx")
-        mean = fields.Array(fields.Float())  # todo: check if means match input axes (for mode 'fixed')
-        std = fields.Array(fields.Float())
-        eps = fields.Float(missing=1e-6)
+        axes = fields.Axes(
+            required=True,
+            valid_axes="czyx",
+            bioimageio_description="The subset of axes to normalize jointly. For example xy to normalize the two image "
+            "axes for 2d data jointly. The batch axis (b) is not valid here.",
+        )
+        mean = fields.Array(
+            fields.Float(),
+            bioimageio_description="The mean value(s) to use for `mode == fixed`. For example `[1.1, 2.2, 3.3]` in the "
+            "case of a 3 channel image where the channels are not normalized jointly.",
+        )  # todo: check if means match input axes (for mode 'fixed')
+        std = fields.Array(
+            fields.Float(),
+            bioimageio_description="The standard deviation values to use for `mode == fixed`. Analogous to mean.",
+        )
+        eps = fields.Float(
+            missing=1e-6,
+            bioimageio_description="epsilon for numeric stability: `out = (tensor - mean) / (std + eps)`. "
+            "Default value: 10^-6.",
+        )
 
         @validates_schema
         def mean_and_std_match_mode(self, data, **kwargs):
             if data["mode"] == "fixed" and ("mean" not in data or "std" not in data):
                 raise ValidationError(
-                    "`kwargs` for 'zero_mean_unit_variance' preprocessing with `mode` 'fixed' require additional `kwargs`: `mean` and `std`."
+                    "`kwargs` for 'zero_mean_unit_variance' preprocessing with `mode` 'fixed' require additional "
+                    "`kwargs`: `mean` and `std`."
                 )
             elif data["mode"] != "fixed" and ("mean" in data or "std" in data):
                 raise ValidationError(
@@ -170,13 +198,24 @@ class Preprocessing(Processing):
     class ScaleRange(SharedProcessingSchema):
         bioimageio_description = "Scale with percentiles"
         mode = fields.ProcMode(required=True, valid_modes=("per_dataset", "per_sample"))
-        axes = fields.Axes(required=True, valid_axes="czyx")
+        axes = fields.Axes(
+            required=True,
+            valid_axes="czyx",
+            bioimageio_description="The subset of axes to normalize jointly. For example xy to normalize the two image "
+            "axes for 2d data jointly. The batch axis (b) is not valid here.",
+        )
         min_percentile = fields.Float(
-            default=0, validate=field_validators.Range(0, 100, min_inclusive=True, max_inclusive=False)
+            default=0,
+            validate=field_validators.Range(0, 100, min_inclusive=True, max_inclusive=False),
+            bioimageio_description="The lower percentile used for normalization, in range 0 to 100. Default value: 0.",
         )
         max_percentile = fields.Float(
-            default=100, validate=field_validators.Range(1, 100, min_inclusive=False, max_inclusive=True)
-        )  # as a precaution 'max_percentile' needs to be greater than 1
+            default=100,
+            validate=field_validators.Range(1, 100, min_inclusive=False, max_inclusive=True),
+            bioimageio_description="The upper percentile used for normalization, in range 1 to 100. Has to be bigger "
+            "than min_percentile. Default value: 100. The range is 1 to 100 instead of 0 to 100 to avoid mistakenly "
+            "accepting percentiles specified in the range 0.0 to 1.0.",
+        )
 
         @validates_schema
         def min_smaller_max(self, data, **kwargs):

--- a/bioimageio/spec/model/v0_3/schema.py
+++ b/bioimageio/spec/model/v0_3/schema.py
@@ -216,6 +216,12 @@ class Preprocessing(Processing):
             "than min_percentile. Default value: 100. The range is 1 to 100 instead of 0 to 100 to avoid mistakenly "
             "accepting percentiles specified in the range 0.0 to 1.0.",
         )
+        eps = fields.Float(
+            missing=1e-6,
+            bioimageio_description="Epsilon for numeric stability: "
+            "`out = (tensor - v_lower) / (v_upper - v_lower + eps)`; "
+            "with `v_lower,v_upper` values at the respective percentiles. Default value: 10^-6.",
+        )
 
         @validates_schema
         def min_smaller_max(self, data, **kwargs):

--- a/bioimageio/spec/shared/fields.py
+++ b/bioimageio/spec/shared/fields.py
@@ -381,7 +381,7 @@ class ProcMode(String):
         **kwargs,
     ) -> None:
         assert all(vm in self.all_modes for vm in valid_modes), valid_modes
-
+        self.valid_modes = valid_modes  # used in doc generation script 'generate_processing_docs.py'
         if validate is None:
             validate = []
 

--- a/bioimageio/spec/shared/schema.py
+++ b/bioimageio/spec/shared/schema.py
@@ -9,7 +9,7 @@ from . import raw_nodes
 
 class SharedBioImageIOSchema(Schema):
     raw_nodes: ClassVar[ModuleType] = raw_nodes  # to be overwritten in subclass by version specific raw_nodes module
-    bioimageio_description: str = ""
+    bioimageio_description: ClassVar[str] = ""
 
     @post_load
     def make_object(self, data, **kwargs):
@@ -30,6 +30,15 @@ class SharedBioImageIOSchema(Schema):
         except TypeError as e:
             e.args += (f"when initializing {this_type} from {self}",)
             raise e
+
+
+class SharedProcessingSchema(Schema):
+    """Used to generate Pre- and Postprocessing documentation.
+
+    Define Pre-/Postprocessing schemas in the Preprocessing/Postprocessing schema that inherite from this class
+    and they will be rendered in the documentation."""
+
+    bioimageio_description: ClassVar[str]
 
 
 class Dependencies(SharedBioImageIOSchema):

--- a/scripts/generate_processing_docs.py
+++ b/scripts/generate_processing_docs.py
@@ -1,0 +1,161 @@
+import dataclasses
+import inspect
+from pathlib import Path
+from typing import List, Tuple, Type
+
+import requests
+
+import bioimageio.spec.model
+from bioimageio.spec.shared.fields import DocumentedField
+from bioimageio.spec.shared.schema import SharedProcessingSchema
+
+REFERENCE_IMPLEMENTATIONS_SOURCE = "https://github.com/bioimage-io/core-bioimage-io-python/blob/main/bioimageio/core/prediction_pipeline/_processing.py"
+REFERENCE_IMPLEMENTATIONS_SOURCE_RAW = "https://raw.githubusercontent.com/bioimage-io/core-bioimage-io-python/main/bioimageio/core/prediction_pipeline/_processing.py"
+
+REFERENCE_IMPLEMENTATIONS = requests.get(REFERENCE_IMPLEMENTATIONS_SOURCE_RAW).text
+
+
+def get_ref_impl(name: str) -> str:
+    # returns link to reference implementation
+    start = None
+    nr = 1
+    for nr, line in enumerate(REFERENCE_IMPLEMENTATIONS.split("\n"), 1):
+        if start is None:
+            if line.startswith(f"class {name}("):  # start of ref implementation
+                start = nr
+        elif line and not line.startswith(" "):  # end of indentation block
+            stop = nr
+            break
+    else:
+        stop = nr
+
+    return f"{REFERENCE_IMPLEMENTATIONS_SOURCE}#L{start}-L{stop}"
+
+
+@dataclasses.dataclass
+class Kwarg:
+    name: str
+    optional: bool
+    description: str
+
+
+@dataclasses.dataclass
+class ProcessingDocNode:
+    name: str
+    description: str
+    kwargs: List[Kwarg]
+    reference_implemation: str
+
+
+@dataclasses.dataclass
+class PreprocessingDocNode(ProcessingDocNode):
+    prefix = "pre"
+
+
+@dataclasses.dataclass
+class PostprocessingDocNode(ProcessingDocNode):
+    prefix = "post"
+
+
+def get_docs(schema) -> Tuple[List[PreprocessingDocNode], List[PostprocessingDocNode]]:
+    """retrieve docs for pre- and postprocessing from schema defintions
+
+    using that pre- and postprocessings are defined as member classes that inherit from SharedProcessingSchema
+    """
+
+    def get_field_descr(f) -> str:
+        assert isinstance(f, DocumentedField), "was a 'regular' marshmallow field in use?"
+        if f.bioimageio_description:
+            return f.bioimageio_description
+        elif isinstance(f, bioimageio.spec.shared.fields.ProcMode):
+            expl = {
+                "fixed": "fixed values for mean and variance",
+                "per_sample": "mean and variance are computed for each sample individually",
+                "per_dataset": "mean and variance are computed for the entire dataset",
+            }
+
+            def add_expl(mode: str) -> str:
+                return f"{mode} ({expl[mode]})"
+
+            return f"One of {', '.join(map(add_expl, f.valid_modes[:-1]))}{' and ' if len(f.valid_modes) > 1 else ''}{add_expl(f.valid_modes[-1])}."
+        else:
+            return ""
+
+    def get_kwargs_doc(Sch: Type[SharedProcessingSchema]) -> List[Kwarg]:
+        return sorted(
+            [
+                Kwarg(name=name, optional=not f.required or bool(f.missing), description=get_field_descr(f))
+                for name, f in Sch().fields.items()
+            ],
+            key=lambda kw: (kw.optional, kw.name),
+        )
+
+    preps = [
+        PreprocessingDocNode(
+            name=name,
+            description=member.bioimageio_description,
+            kwargs=get_kwargs_doc(member),
+            reference_implemation=get_ref_impl(name),
+        )
+        for name, member in inspect.getmembers(schema.Preprocessing)
+        if inspect.isclass(member) and issubclass(member, SharedProcessingSchema)
+    ]
+    posts = [
+        PostprocessingDocNode(
+            name=name,
+            description=member.bioimageio_description,
+            kwargs=get_kwargs_doc(member),
+            reference_implemation=get_ref_impl(name),
+        )
+        for name, member in inspect.getmembers(schema.Postprocessing)
+        if inspect.isclass(member) and issubclass(member, SharedProcessingSchema)
+    ]
+    return preps, posts
+
+
+def markdown_from_docs(doc_nodes: List[ProcessingDocNode], title: str, description: str):
+    md = f"# {title}\n{description}\n"
+
+    for doc in doc_nodes:
+        md += f"- `{doc.name}` {doc.description}\n"
+        if doc.kwargs:
+            md += f"  - key word arguments:\n"
+            for kwarg in doc.kwargs:
+                md += f"    - `{'[' if kwarg.optional else ''}{kwarg.name}{']' if kwarg.optional else ''}` {kwarg.description}\n"
+        md += f"  - reference implementation: {doc.reference_implemation}\n"
+
+    return md
+
+
+def export_markdown_docs(folder: Path, spec) -> None:
+    model_or_version = spec.__name__.split(".")[-1]
+    format_version_wo_patch = ".".join(spec.format_version.split(".")[:2])
+    if model_or_version == "model":
+        format_version_file_name = "latest"
+    else:
+        format_version_file_name = format_version_wo_patch.replace(".", "_")
+
+    for docs in get_docs(spec.schema):
+        assert isinstance(docs, list)
+        prefix = docs[0].prefix
+        md = markdown_from_docs(
+            docs,
+            title=f"{prefix.title()}processing operations in model spec {format_version_wo_patch}",
+            description=(
+                f"The supported operations that are valid in {prefix}processing. "
+                "IMPORTANT: these operations must return float32 tensors, so that their output can be consumed by the "
+                "models."
+            ),
+        )
+        path = folder / f"{prefix}processing_spec_{format_version_file_name}.md"
+        path.write_text(md, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    import bioimageio.spec.model.v0_3
+
+    dist = Path(__file__).parent / "../dist"
+    dist.mkdir(exist_ok=True)
+
+    export_markdown_docs(dist, bioimageio.spec.model.v0_3)
+    export_markdown_docs(dist, bioimageio.spec.model)


### PR DESCRIPTION
This PR generates the pre-/postprocessing documentation (currently at https://github.com/bioimage-io/spec-bioimage-io/blob/1bf7c5c5a5e4aef1dc4041f0c3867d150596b811/supported_formats_and_operations.md#preprocessing) from descriptions provided in the schema defintion.

Also this PR:
 - adds an `eps`(ilon) field to `ScaleRange` as discussed in https://github.com/bioimage-io/core-bioimage-io-python/pull/142
 - modifies the CI workflow to deploy PR branches to a 'gh-pages-<PR branch name>` preview
 - adds a new workflow that cleans up the above mentioned preview branches as well  as deletes merged PR branches