### PR TITLE
consider only URIs with scheme valid

### DIFF
--- a/bioimageio/spec/shared/fields.py
+++ b/bioimageio/spec/shared/fields.py
@@ -426,4 +426,4 @@ class URI(String):
         try:
             return raw_nodes.URI(uri_string=value)
         except Exception as e:
-            raise ValidationError(value) from e
+            raise ValidationError(str(e)) from e

--- a/bioimageio/spec/shared/raw_nodes.py
+++ b/bioimageio/spec/shared/raw_nodes.py
@@ -104,6 +104,8 @@ class URI(RawNode):
 
         if not self.scheme:
             raise ValueError("Empty URI scheme component")
+        elif len(self.scheme) == 1:
+            raise ValueError(f"Invalid URI scheme of len 1: {self.scheme}")  # fail for windows paths with drive letter
 
         super().__post_init__()
 


### PR DESCRIPTION
and even only with len(scheme) > 1 to avoid issues with windows path's drive letters.

This PR is necessary for `fields.Union[fields.URI(), fields.Path]` to work as expected, i.e. URI needs to fail for strings that are actually paths. 