### PR TITLE
add and use YamlDict

### DIFF
--- a/bioimageio/spec/model/v0_3/schema.py
+++ b/bioimageio/spec/model/v0_3/schema.py
@@ -630,7 +630,7 @@ is in an unsupported format version. The current format version described here i
         "`sample_inputs`.",
     )
 
-    config = fields.Dict(
+    config = fields.YamlDict(
         bioimageio_description=rdf.schema.RDF.config_bioimageio_description
         + """
 

--- a/bioimageio/spec/rdf/v0_2/schema.py
+++ b/bioimageio/spec/rdf/v0_2/schema.py
@@ -120,7 +120,7 @@ E.g. the citation for the model architecture and/or the training data used."""
 """
         "    If possible, please use [`snake_case`](https://en.wikipedia.org/wiki/Snake_case) for keys in `config`."
     )
-    config = fields.Dict(bioimageio_descriptio=config_bioimageio_description)
+    config = fields.YamlDict(bioimageio_descriptio=config_bioimageio_description)
 
     covers = fields.List(
         fields.Union(

--- a/bioimageio/spec/shared/fields.py
+++ b/bioimageio/spec/shared/fields.py
@@ -105,6 +105,27 @@ class Dict(DocumentedField, marshmallow_fields.Dict):
         self.type_name += f"\\[{key}, {value}\\]"
 
 
+class YamlDict(Dict):
+    """yaml friendly dict"""
+
+    @staticmethod
+    def _make_yaml_friendly(obj):
+        if isinstance(obj, (list, tuple)):
+            return [YamlDict._make_yaml_friendly(ob) for ob in obj]
+        elif isinstance(obj, dict):
+            return {YamlDict._make_yaml_friendly(k): YamlDict._make_yaml_friendly(v) for k, v in obj.items()}
+        elif obj is None or isinstance(obj, (float, int, str, bool)):
+            return obj
+        elif isinstance(obj, pathlib.PurePath):
+            return obj.as_posix()
+        else:
+            raise TypeError(f"Encountered YAML unfriendly type: {type(obj)}")
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        value = self._make_yaml_friendly(value)
+        return super()._serialize(value, attr, obj, **kwargs)
+
+
 class Float(DocumentedField, marshmallow_fields.Float):
     pass
 


### PR DESCRIPTION
to help serializing the config field

e.g. allows to use `pathlib.Path` in the `config` field when initializing a `raw_nodes.Model` in python, which for example happens in the `build_model` helper from `bioimageio.core`. 