### PR TITLE
Move sha256 field for pytorch weights

### DIFF
--- a/bioimageio/spec/model/v0_1/raw_nodes.py
+++ b/bioimageio/spec/model/v0_1/raw_nodes.py
@@ -37,6 +37,7 @@ class BaseSpec(RawNode):
     language: str = missing
     framework: Union[_Missing, str] = missing
     source: str = missing
+    hash: Dict[str, str] = missing
     required_kwargs: Union[_Missing, List[str]] = missing
     optional_kwargs: Union[_Missing, Dict[str, Any]] = missing
 

--- a/bioimageio/spec/model/v0_1/schema.py
+++ b/bioimageio/spec/model/v0_1/schema.py
@@ -33,6 +33,7 @@ class BaseSpec(BioImageIOSchema):
     documentation = fields.RelativeLocalPath(required=True)
     tags = fields.List(fields.String(), required=True)
     license = fields.String(required=True)
+    hash = fields.Dict()
 
     language = fields.String(required=True)
     framework = fields.String()

--- a/bioimageio/spec/model/v0_3/converters.py
+++ b/bioimageio/spec/model/v0_3/converters.py
@@ -81,6 +81,8 @@ def convert_model_from_v0_1(data: Dict[str, Any]) -> Dict[str, Any]:
         conversion_errors["prediction"]["weights"]["hash"]["sha256"] = missing
         sha256 = missing
 
+    data["sha256"] = data.pop("hash", {}).pop("sha256", missing)
+
     try:
         data["dependencies"] = data["prediction"].pop("dependencies")
     except KeyError:

--- a/bioimageio/spec/model/v0_4/converters.py
+++ b/bioimageio/spec/model/v0_4/converters.py
@@ -1,6 +1,8 @@
 import copy
 from typing import Any, Dict
 
+from marshmallow import missing
+
 
 def convert_model_from_v0_3(data: Dict[str, Any]) -> Dict[str, Any]:
     from bioimageio.spec.model import v0_3
@@ -13,12 +15,19 @@ def convert_model_from_v0_3(data: Dict[str, Any]) -> Dict[str, Any]:
     data.pop("language", None)
     data.pop("framework", None)
 
-    architecture = data.pop("source", None)
-    kwargs = data.pop("kwargs", None)
+    architecture = data.pop("source", missing)
+    architecture_sha256 = data.pop("sha256", missing)
+    kwargs = data.pop("kwargs", missing)
     pytorch_state_dict_weights_entry = data.get("weights", {}).get("pytorch_state_dict")
     if pytorch_state_dict_weights_entry is not None:
-        pytorch_state_dict_weights_entry["architecture"] = architecture
-        pytorch_state_dict_weights_entry["kwargs"] = kwargs
+        if architecture is not missing:
+            pytorch_state_dict_weights_entry["architecture"] = architecture
+
+        if architecture_sha256 is not missing:
+            pytorch_state_dict_weights_entry["architecture_sha256"] = architecture_sha256
+
+        if architecture_sha256 is not missing:
+            pytorch_state_dict_weights_entry["kwargs"] = kwargs
 
     data["format_version"] = "0.4.0"
 

--- a/bioimageio/spec/model/v0_4/raw_nodes.py
+++ b/bioimageio/spec/model/v0_4/raw_nodes.py
@@ -55,6 +55,7 @@ ImportableSource = Union[ImportableSourceFile, ImportableModule]
 class PytorchStateDictWeightsEntry(_WeightsEntryBase):
     weights_format_name = "Pytorch State Dict"
     architecture: ImportableSource = missing
+    architecture_sha256: Union[_Missing, str] = missing
     kwargs: Union[_Missing, Dict[str, Any]] = missing
 
 
@@ -84,7 +85,6 @@ class Model(_RDF):
     run_mode: Union[_Missing, RunMode] = missing
     sample_inputs: Union[_Missing, List[Union[URI, Path]]] = missing
     sample_outputs: Union[_Missing, List[Union[URI, Path]]] = missing
-    sha256: Union[_Missing, str] = missing
     timestamp: datetime = missing
     type: Literal["model"] = missing
 

--- a/example_specs/models/unet2d_diff_output_shape/rdf.yaml
+++ b/example_specs/models/unet2d_diff_output_shape/rdf.yaml
@@ -40,6 +40,7 @@ type: model
 weights:
   pytorch_state_dict:
     architecture: ./resize_unet.py:ResizeUNet
+    architecture_sha256: bc9e7fe5dd5d3a6c7a4ef7d32b6704169f887b7632f898fc07c762eea7a3feb5
     kwargs: {depth: 3, in_channels: 1, initial_features: 16, out_channels: 1}
     sha256: 2c475874f358eb75dc5f3b6af8d186e4fbf8da3acf43fb6662f0d5de21b0a838
     source: ./weights.pt

--- a/example_specs/models/unet2d_multi_tensor/rdf.yaml
+++ b/example_specs/models/unet2d_multi_tensor/rdf.yaml
@@ -65,6 +65,7 @@ weights:
     source: ./weights-torchscript.pt
   pytorch_state_dict:
     architecture: ./multi_tensor_unet.py:MultiTensorUNet
+    architecture_sha256: 5e3d36b5187b85d5c935f2efde7cafe293dbffa413618f49a0744bf1be75c22b
     kwargs: {depth: 3, in_channels: 2, initial_features: 16, out_channels: 2}
     sha256: c498522b3f2b02429b41fe9dbcb722ce0d7ad4cae7fcf8059cee27857ae49b00
     source: ./weights.pt

--- a/example_specs/models/unet2d_nuclei_broad/invalid_rdf_v0_4_0_duplicate_tensor_names.yaml
+++ b/example_specs/models/unet2d_nuclei_broad/invalid_rdf_v0_4_0_duplicate_tensor_names.yaml
@@ -69,6 +69,7 @@ weights:
    sha256: e4d3885bccbe41cbf6c1d825f3cd2b707c7021ead5593156007e407a16b27cf2
    source: https://zenodo.org/record/3446812/files/unet2d_weights.torch
    architecture: unet2d.py:UNet2d
+   architecture_sha256: cf42a6d86adeb4eb6e8e37b539a20e5413866b183bed88f4e2e26ad1639761ed
    kwargs: {input_channels: 1, output_channels: 1}
  onnx:
    sha256: 5bf14c4e65e8601ab551db99409ba7981ff0e501719bc2b0ee625ca9a9375b32

--- a/example_specs/models/unet2d_nuclei_broad/rdf.yaml
+++ b/example_specs/models/unet2d_nuclei_broad/rdf.yaml
@@ -69,6 +69,7 @@ weights:
    sha256: e4d3885bccbe41cbf6c1d825f3cd2b707c7021ead5593156007e407a16b27cf2
    source: https://zenodo.org/record/3446812/files/unet2d_weights.torch
    architecture: unet2d.py:UNet2d
+   architecture_sha256: cf42a6d86adeb4eb6e8e37b539a20e5413866b183bed88f4e2e26ad1639761ed
    kwargs: {input_channels: 1, output_channels: 1}
  onnx:
    sha256: 5bf14c4e65e8601ab551db99409ba7981ff0e501719bc2b0ee625ca9a9375b32

--- a/example_specs/models/unet2d_nuclei_broad/rdf_v0_1_0.yaml
+++ b/example_specs/models/unet2d_nuclei_broad/rdf_v0_1_0.yaml
@@ -40,6 +40,7 @@ outputs:
 language: python
 framework: pytorch
 source: unet2d.py:UNet2d
+hash: {sha256: cf42a6d86adeb4eb6e8e37b539a20e5413866b183bed88f4e2e26ad1639761ed}
 optional_kwargs: {input_channels: 1, output_channels: 1}
 
 test_input: test_input.npy

--- a/example_specs/models/unet2d_nuclei_broad/rdf_v0_3_0.yaml
+++ b/example_specs/models/unet2d_nuclei_broad/rdf_v0_3_0.yaml
@@ -50,6 +50,7 @@ outputs:
 language: python
 framework: pytorch
 source: unet2d.py:UNet2d
+sha256: cf42a6d86adeb4eb6e8e37b539a20e5413866b183bed88f4e2e26ad1639761ed
 kwargs: {input_channels: 1, output_channels: 1}
 dependencies: conda:environment.yaml
 

--- a/example_specs/models/unet2d_nuclei_broad/rdf_v0_3_1.yaml
+++ b/example_specs/models/unet2d_nuclei_broad/rdf_v0_3_1.yaml
@@ -50,6 +50,7 @@ outputs:
 language: python
 framework: pytorch
 source: unet2d.py:UNet2d
+sha256: cf42a6d86adeb4eb6e8e37b539a20e5413866b183bed88f4e2e26ad1639761ed
 kwargs: {input_channels: 1, output_channels: 1}
 dependencies: conda:environment.yaml
 

--- a/example_specs/models/unet2d_nuclei_broad/rdf_v0_3_2.yaml
+++ b/example_specs/models/unet2d_nuclei_broad/rdf_v0_3_2.yaml
@@ -55,6 +55,7 @@ outputs:
 language: python
 framework: pytorch
 source: unet2d.py:UNet2d
+sha256: cf42a6d86adeb4eb6e8e37b539a20e5413866b183bed88f4e2e26ad1639761ed
 kwargs: {input_channels: 1, output_channels: 1}
 dependencies: conda:environment.yaml
 

--- a/example_specs/models/unet2d_nuclei_broad/rdf_v0_3_3.yaml
+++ b/example_specs/models/unet2d_nuclei_broad/rdf_v0_3_3.yaml
@@ -55,6 +55,7 @@ outputs:
 language: python
 framework: pytorch
 source: unet2d.py:UNet2d
+sha256: cf42a6d86adeb4eb6e8e37b539a20e5413866b183bed88f4e2e26ad1639761ed
 kwargs: {input_channels: 1, output_channels: 1}
 dependencies: conda:environment.yaml
 

--- a/tests/test_schema_model.py
+++ b/tests/test_schema_model.py
@@ -77,6 +77,7 @@ def test_model_schema_accepts_valid_weight_formats(model_dict, format):
     model_dict.update({"weights": {format: {"source": "local_weights"}}})
     if format == "pytorch_state_dict":
         model_dict["weights"][format]["architecture"] = "file.py:Model"
+        model_dict["weights"][format]["architecture_sha256"] = "0" * 64  # dummy sha256
 
     validated_data = model_schema.load(model_dict)
     assert validated_data
@@ -98,6 +99,7 @@ def test_model_0_4_raises_on_duplicate_tensor_names(invalid_rdf_v0_4_0_duplicate
     data["framework"] = "pytorch"
     data["source"] = data["weights"]["pytorch_state_dict"].pop("architecture")
     data["kwargs"] = data["weights"]["pytorch_state_dict"].pop("kwargs")
+    data["sha256"] = data["weights"]["pytorch_state_dict"].pop("architecture_sha256")
 
     valid_data = model_schema.load(data)
     assert valid_data


### PR DESCRIPTION
also enforces the field (now called `architecture_sha256` in the pytorch model dict weights if `architecture` points to a file (and not a module).

todo:
 - [ ] fix: Enforcing it invalidates some of the older models we still use in testing.. 