### PR TITLE
Add support for real zenodo doi

### DIFF
--- a/bioimageio/spec/io_.py
+++ b/bioimageio/spec/io_.py
@@ -72,11 +72,22 @@ def resolve_rdf_source(
             import requests
             from urllib.request import urlopen
 
+            zenodo_prefix = "10.5281/zenodo."
+            zenodo_record_api = "https://zenodo.org/api/records"
             zenodo_sandbox_prefix = "10.5072/zenodo."
-            if source.startswith(zenodo_sandbox_prefix):
+            zenodo_sandbox_record_api = "https://sandbox.zenodo.org/api/records"
+            is_zenodo_doi = False
+            if source.startswith(zenodo_prefix):
+                is_zenodo_doi = True
+            elif source.startswith(zenodo_sandbox_prefix):
                 # zenodo sandbox doi (which is not a valid doi)
-                record_id = source[len(zenodo_sandbox_prefix) :]
-                response = requests.get(f"https://sandbox.zenodo.org/api/records/{record_id}")
+                zenodo_prefix = zenodo_sandbox_prefix
+                zenodo_record_api = zenodo_sandbox_record_api
+                is_zenodo_doi = True
+
+            if is_zenodo_doi:
+                record_id = source[len(zenodo_prefix) :]
+                response = requests.get(f"{zenodo_record_api}/{record_id}")
                 if not response.ok:
                     raise RuntimeError(response.status_code)
 

--- a/bioimageio/spec/model/v0_4/converters.py
+++ b/bioimageio/spec/model/v0_4/converters.py
@@ -3,6 +3,8 @@ from typing import Any, Dict
 
 from marshmallow import missing
 
+from bioimageio.spec.exceptions import UnconvertibleError
+
 
 def convert_model_from_v0_3(data: Dict[str, Any]) -> Dict[str, Any]:
     from bioimageio.spec.model import v0_3
@@ -23,8 +25,10 @@ def convert_model_from_v0_3(data: Dict[str, Any]) -> Dict[str, Any]:
         if architecture is not missing:
             pytorch_state_dict_weights_entry["architecture"] = architecture
 
-        if architecture_sha256 is not missing:
-            pytorch_state_dict_weights_entry["architecture_sha256"] = architecture_sha256
+        if architecture_sha256 is missing:
+            raise UnconvertibleError("Missing 'sha256' which is now required.")
+
+        pytorch_state_dict_weights_entry["architecture_sha256"] = architecture_sha256
 
         if architecture_sha256 is not missing:
             pytorch_state_dict_weights_entry["kwargs"] = kwargs

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -33,7 +33,12 @@ def test_validate_model_as_zenodo_sandbox_doi():
     assert not validate(doi, update_format=False, update_format_inner=False)["error"]
 
 
-# todo: add test with real doi
+def test_validate_model_as_zenodo_doi():
+    from bioimageio.spec.commands import validate
+
+    doi = "10.5281/zenodo.5744490"
+    assert not validate(doi, update_format=True, update_format_inner=False)["error"]
+    assert not validate(doi, update_format=False, update_format_inner=False)["error"]
 
 
 def test_validate_model_as_bytes_io(unet2d_nuclei_broad_latest_path):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,7 +2,10 @@ import zipfile
 from copy import copy
 from io import BytesIO, StringIO
 
+import pytest
+
 from bioimageio.spec import load_raw_resource_description
+from bioimageio.spec.exceptions import UnconvertibleError
 from bioimageio.spec.model import format_version
 
 
@@ -40,8 +43,10 @@ def test_validate_model_as_zenodo_doi():
     from bioimageio.spec.commands import validate
 
     doi = "10.5281/zenodo.5744490"
-    assert not validate(doi, update_format=True, update_format_inner=False)["error"]
     assert not validate(doi, update_format=False, update_format_inner=False)["error"]
+
+    # expecting UnconvertibleError due to missing sha256
+    assert validate(doi, update_format=True, update_format_inner=False)["error"]
 
 
 def test_validate_model_as_bytes_io(unet2d_nuclei_broad_latest_path):


### PR DESCRIPTION
The test fails for me with:
```
    def test_validate_model_as_zenodo_doi():
        from bioimageio.spec.commands import validate
    
        doi = "10.5281/zenodo.5744490"
>       assert not validate(doi, update_format=True, update_format_inner=False)["error"]
E       assert not "expected loaded resource to be a dictionary, but got type <class 'str'>: 10.5281/zenodo.5744490"
```
@FynnBe so looks like we still need to fix some things before we can support normal zenodo dois.