### PR TITLE
flat warnings

### DIFF
--- a/bioimageio/spec/commands.py
+++ b/bioimageio/spec/commands.py
@@ -6,7 +6,7 @@ from typing import Dict, IO, Union
 from marshmallow import ValidationError
 
 from .io_ import load_raw_resource_description, resolve_rdf_source
-from .shared.common import nested_default_dict_as_nested_dict
+from .shared.common import ValidationWarning, nested_default_dict_as_nested_dict
 
 KNOWN_COLLECTION_CATEGORIES = ("application", "collection", "dataset", "model", "notebook")
 
@@ -26,7 +26,7 @@ def validate(
         verbose: deprecated
 
     Returns:
-        A summary dict with "error", "traceback" and "nested_errors" keys.
+        A summary dict with "error", "warnings", "traceback" and "nested_errors" keys.
     """
     if verbose != "deprecated":
         warnings.warn("'verbose' flag is deprecated")
@@ -52,14 +52,16 @@ def validate(
 
     raw_rd = None
     if error is None:
-        try:
-            raw_rd = load_raw_resource_description(rdf_source, update_to_current_format=update_format)
-        except ValidationError as e:
-            error = nested_default_dict_as_nested_dict(e.normalized_messages())
-        except Exception as e:
-            error = str(e)
-            tb = traceback.format_tb(e.__traceback__)
+        with warnings.catch_warnings(record=True) as all_warnings:
+            try:
+                raw_rd = load_raw_resource_description(rdf_source, update_to_current_format=update_format)
+            except ValidationError as e:
+                error = nested_default_dict_as_nested_dict(e.normalized_messages())
+            except Exception as e:
+                error = str(e)
+                tb = traceback.format_tb(e.__traceback__)
 
+        validation_warnings = [w for w in all_warnings if issubclass(w.category, ValidationWarning)]
         if raw_rd is not None and raw_rd.type == "collection":
             for inner_category in KNOWN_COLLECTION_CATEGORIES:
                 for inner in getattr(raw_rd, inner_category) or []:
@@ -75,11 +77,14 @@ def validate(
 
             if nested_errors:
                 error = f"Errors in collections of {list(nested_errors)}"
+    else:
+        validation_warnings = []
 
     return {
         "name": source_name if raw_rd is None else raw_rd.name,
         "source_name": source_name,
         "error": error,
+        "warnings": ValidationWarning.get_warning_summary(validation_warnings),
         "traceback": tb,
         "nested_errors": nested_errors,
     }

--- a/bioimageio/spec/model/v0_4/schema.py
+++ b/bioimageio/spec/model/v0_4/schema.py
@@ -11,7 +11,6 @@ from bioimageio.spec.model.v0_3.schema import (
     Postprocessing,
     Preprocessing,
     PytorchScriptWeightsEntry,
-    RunMode,
     TensorflowJsWeightsEntry,
     TensorflowSavedModelBundleWeightsEntry,
     _WeightsEntryBase,
@@ -252,6 +251,16 @@ WeightsEntry = typing.Union[
     TensorflowSavedModelBundleWeightsEntry,
     OnnxWeightsEntry,
 ]
+
+
+class RunMode(_BioImageIOSchema):
+    name = fields.String(required=True, bioimageio_description="The name of the `run_mode`")
+    kwargs = fields.Kwargs()
+
+    @validates("name")
+    def warn_on_unrecognized_run_mode(self, value: str):
+        if isinstance(value, str):
+            self.warn("name", f"Unrecognized run mode '{value}'")
 
 
 class Model(rdf.schema.RDF):

--- a/bioimageio/spec/rdf/v0_2/schema.py
+++ b/bioimageio/spec/rdf/v0_2/schema.py
@@ -1,6 +1,6 @@
 import warnings
 
-from marshmallow import EXCLUDE, ValidationError, validates, validates_schema
+from marshmallow import EXCLUDE, ValidationError, post_load, validates, validates_schema
 
 from bioimageio.spec.shared import LICENSES, field_validators, fields
 from bioimageio.spec.shared.common import get_args, get_patched_format_version
@@ -207,6 +207,14 @@ E.g. the citation for the model architecture and/or the training data used."""
 
     # todo: warn about length
     name = fields.String(required=True, bioimageio_description="name of the resource, a human-friendly name")
+
+    @post_load
+    def warn_about_long_name(self, value: str, **kwargs):
+        if isinstance(value, str):
+            if len(value) > 64:
+                warnings.warn(f"Length of name ({len(value)}) exceeds the recommended maximum length of 64 characters.")
+        else:
+            warnings.warn(f"Could not check length of name {value}.")
 
     source = fields.Union(
         [fields.URI(), fields.RelativeLocalPath()],

--- a/bioimageio/spec/rdf/v0_2/schema.py
+++ b/bioimageio/spec/rdf/v0_2/schema.py
@@ -188,13 +188,13 @@ E.g. the citation for the model architecture and/or the training data used."""
         if license_info is None:
             self.warn("license", f"{value} is not a recognized SPDX license identifier. See https://spdx.org/licenses/")
         else:
-            if license_info["isDeprecatedLicenseId"]:
+            if license_info.get("isDeprecatedLicenseId", False):
                 self.warn("license", f"{value} ({license_info['name']}) is deprecated")
 
-            if not license_info["isOsiApproved"]:
+            if not license_info.get("isOsiApproved", False):
                 self.warn("license", f"{value} ({license_info['name']}) is not approved by OSI")
 
-            if not license_info["isFsfLibre"]:
+            if not license_info.get("isFsfLibre", False):
                 self.warn("license", f"{value} ({license_info['name']}) is not FSF Free/libre.")
 
     links = fields.List(fields.String(), bioimageio_description="links to other bioimage.io resources")

--- a/bioimageio/spec/shared/common.py
+++ b/bioimageio/spec/shared/common.py
@@ -28,14 +28,6 @@ BIOIMAGEIO_CACHE_PATH = pathlib.Path(
 class ValidationWarning(UserWarning):
     """a warning category to warn with during RDF validation"""
 
-    def __init__(self, msg: str):
-        if ": " in msg:
-            self.field = msg.split(": ")[0]
-        else:
-            self.field = ""
-
-        super().__init__(msg)
-
     @staticmethod
     def get_warning_summary(val_warns: Sequence[warnings.WarningMessage]):
         """Summarize warning messsages of the ValidationWarning category"""
@@ -66,9 +58,17 @@ class ValidationWarning(UserWarning):
 
         summary: dict = {}
         for vw in val_warns:
-            assert isinstance(vw.category, ValidationWarning)
-            keys = vw.category.field.split(":")
-            add_to_summary(summary, keys, vw.message)
+            assert issubclass(vw.category, ValidationWarning)
+            msg = str(vw.message)
+            if ": " in msg:
+                assert msg.count(": ")
+                keys_, *rest = msg.split(": ")
+                msg = ": ".join(rest)
+                keys = keys_.split(":")
+            else:
+                keys = []
+
+            add_to_summary(summary, keys, msg)
 
         return summary
 

--- a/bioimageio/spec/shared/common.py
+++ b/bioimageio/spec/shared/common.py
@@ -1,8 +1,8 @@
 import os
 import pathlib
 import tempfile
-from typing import Generic, Optional
-
+import warnings
+from typing import Generic, Optional, Sequence
 
 try:
     from typing import Literal, get_args, get_origin, Protocol
@@ -23,6 +23,54 @@ DOI_REGEX = r"^10[.][0-9]{4,9}\/[-._;()\/:A-Za-z0-9]+$"
 BIOIMAGEIO_CACHE_PATH = pathlib.Path(
     os.getenv("BIOIMAGEIO_CACHE_PATH", pathlib.Path(tempfile.gettempdir()) / "bioimageio_cache")
 )
+
+
+class ValidationWarning(UserWarning):
+    """a warning category to warn with during RDF validation"""
+
+    def __init__(self, msg: str):
+        if ": " in msg:
+            self.field = msg.split(": ")[0]
+        else:
+            self.field = ""
+
+        super().__init__(msg)
+
+    @staticmethod
+    def get_warning_summary(val_warns: Sequence[warnings.WarningMessage]):
+        """Summarize warning messsages of the ValidationWarning category"""
+
+        def add_to_summary(s, keys, msg):
+            key = keys.pop(0)
+            if "[" in key:
+                key, rest = key.split("[")
+                assert rest[-1] == "]"
+                idx = int(rest[:-1])
+            else:
+                idx = None
+
+            if key not in s:
+                s[key] = {} if keys or idx is not None else msg
+
+            s = s[key]
+
+            if idx is not None:
+                if idx not in s:
+                    s[idx] = {} if keys else msg
+
+                s = s[idx]
+
+            if keys:
+                assert isinstance(s, dict)
+                add_to_summary(s, keys, msg)
+
+        summary: dict = {}
+        for vw in val_warns:
+            assert isinstance(vw.category, ValidationWarning)
+            keys = vw.category.field.split(":")
+            add_to_summary(summary, keys, vw.message)
+
+        return summary
 
 
 def get_format_version_module(type_: str, format_version: str):

--- a/bioimageio/spec/shared/schema.py
+++ b/bioimageio/spec/shared/schema.py
@@ -35,9 +35,12 @@ class SharedBioImageIOSchema(Schema):
 
     def warn(self, field: str, msg: str):
         """warn about a field with a ValidationWarning"""
+        field_instance = self.fields[field]
         assert ":" not in field
         assert " " not in field
-        field = ":".join(self.context.get("field_path", []) + [field])
+        # todo: add spec trail to field
+        # e.g. something similar to field = ":".join(self.context.get("field_path", []) + [field])
+        # or: ":".join(field_instance.spec_trail)
         msg = f"{field}: {msg}"
         warnings.warn(msg, category=ValidationWarning)
 

--- a/bioimageio/spec/shared/schema.py
+++ b/bioimageio/spec/shared/schema.py
@@ -1,3 +1,4 @@
+import warnings
 from types import ModuleType
 from typing import ClassVar, List
 
@@ -5,6 +6,7 @@ from marshmallow import Schema, ValidationError, post_load, validates, validates
 
 from bioimageio.spec.shared import fields
 from . import raw_nodes
+from .common import ValidationWarning
 
 
 class SharedBioImageIOSchema(Schema):
@@ -30,6 +32,14 @@ class SharedBioImageIOSchema(Schema):
         except TypeError as e:
             e.args += (f"when initializing {this_type} from {self}",)
             raise e
+
+    def warn(self, field: str, msg: str):
+        """warn about a field with a ValidationWarning"""
+        assert ":" not in field
+        assert " " not in field
+        field = ":".join(self.context.get("field_path", []) + [field])
+        msg = f"{field}: {msg}"
+        warnings.warn(msg, category=ValidationWarning)
 
 
 class SharedProcessingSchema(Schema):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -103,3 +103,14 @@ def test_validate_invalid_model(unet2d_nuclei_broad_latest):
     del data["test_inputs"]  # invalidate data
     assert validate(data, update_format=True, update_format_inner=False)["error"]
     assert validate(data, update_format=False, update_format_inner=False)["error"]
+
+
+def test_validate_generates_warnings(unet2d_nuclei_broad_latest):
+    from bioimageio.spec.commands import validate
+
+    data = copy(unet2d_nuclei_broad_latest)
+    # data["license"] = "BSD-2-Clause-FreeBSD"
+    data["run_mode"] = {"name": "fancy"}
+    summary = validate(data, update_format=True, update_format_inner=False)
+
+    assert summary["warnings"]


### PR DESCRIPTION
flat warnings work fine. they are just flat in the sense that they only contain the field name and no information about how this field is nested within the spec.