### PR TITLE
rename weights format pytorch_script to torchscript

### DIFF
--- a/bioimageio/spec/model/v0_4/converters.py
+++ b/bioimageio/spec/model/v0_4/converters.py
@@ -29,6 +29,10 @@ def convert_model_from_v0_3(data: Dict[str, Any]) -> Dict[str, Any]:
         if architecture_sha256 is not missing:
             pytorch_state_dict_weights_entry["kwargs"] = kwargs
 
+    torchscript_weights_entry = data.get("weights", {}).pop("pytorch_script", None)
+    if torchscript_weights_entry is not None:
+        data["weights"]["torchscript"] = torchscript_weights_entry
+
     data["format_version"] = "0.4.0"
 
     return data

--- a/bioimageio/spec/model/v0_4/raw_nodes.py
+++ b/bioimageio/spec/model/v0_4/raw_nodes.py
@@ -16,11 +16,9 @@ from bioimageio.spec.model.v0_3.raw_nodes import (
     PreprocessingName,
     Postprocessing,
     Preprocessing,
-    PytorchScriptWeightsEntry,
     RunMode,
     TensorflowJsWeightsEntry,
     TensorflowSavedModelBundleWeightsEntry,
-    WeightsFormat,
     _WeightsEntryBase,
 )
 from bioimageio.spec.rdf.v0_2.raw_nodes import CiteEntry, Dependencies, RDF as _RDF
@@ -48,6 +46,9 @@ Preprocessing = Preprocessing
 PreprocessingName = PreprocessingName
 
 FormatVersion = Literal["0.4.0"]  # newest format needs to be last (used in __init__.py)
+WeightsFormat = Literal[
+    "pytorch_state_dict", "torchscript", "keras_hdf5", "tensorflow_js", "tensorflow_saved_model_bundle", "onnx"
+]
 
 ImportableSource = Union[ImportableSourceFile, ImportableModule]
 
@@ -86,13 +87,18 @@ class PytorchStateDictWeightsEntry(_WeightsEntryBase):
     kwargs: Union[_Missing, Dict[str, Any]] = missing
 
 
+@dataclass
+class TorchscriptWeightsEntry(_WeightsEntryBase):
+    weights_format_name = "Torchscript"
+
+
 WeightsEntry = Union[
     KerasHdf5WeightsEntry,
     OnnxWeightsEntry,
-    PytorchScriptWeightsEntry,
     PytorchStateDictWeightsEntry,
     TensorflowJsWeightsEntry,
     TensorflowSavedModelBundleWeightsEntry,
+    TorchscriptWeightsEntry,
 ]
 
 

--- a/bioimageio/spec/model/v0_4/schema.py
+++ b/bioimageio/spec/model/v0_4/schema.py
@@ -244,13 +244,20 @@ class PytorchStateDictWeightsEntry(_WeightsEntryBase):
                 )
 
 
+class TorchscriptWeightsEntry(_WeightsEntryBase):
+    raw_nodes = raw_nodes
+
+    bioimageio_description = "Torchscript weights format"
+    weights_format = fields.String(validate=field_validators.Equal("torchscript"), required=True, load_only=True)
+
+
 WeightsEntry = typing.Union[
-    PytorchStateDictWeightsEntry,
-    PytorchScriptWeightsEntry,
     KerasHdf5WeightsEntry,
+    OnnxWeightsEntry,
+    PytorchStateDictWeightsEntry,
     TensorflowJsWeightsEntry,
     TensorflowSavedModelBundleWeightsEntry,
-    OnnxWeightsEntry,
+    TorchscriptWeightsEntry,
 ]
 
 

--- a/example_specs/models/unet2d_multi_tensor/rdf.yaml
+++ b/example_specs/models/unet2d_multi_tensor/rdf.yaml
@@ -60,7 +60,7 @@ weights:
     opset_version: 12
     sha256: 9b5bd88a3d29cf9979b30c03b4d5af12fdfa1d7193f5d2f2cc3942ffcf71ce3c
     source: ./weights.onnx
-  pytorch_script:
+  torchscript:
     sha256: 097bb5062df1fe48a5e7473ea2f6025c77d334a9e3f92af79fc3d6d530c01720
     source: ./weights-torchscript.pt
   pytorch_state_dict:

--- a/example_specs/models/unet2d_nuclei_broad/rdf.yaml
+++ b/example_specs/models/unet2d_nuclei_broad/rdf.yaml
@@ -80,7 +80,7 @@ weights:
    source: weights.onnx
    opset_version: 12
    parent: https://zenodo.org/record/3446812/files/unet2d_weights.torch
- pytorch_script:
+ torchscript:
    sha256: 62fa1c39923bee7d58a192277e0dd58f2da9ee810662addadd0f44a3784d9210
    source: weights.pt
    parent: https://zenodo.org/record/3446812/files/unet2d_weights.torch

--- a/scripts/generate_weight_formats_overview.py
+++ b/scripts/generate_weight_formats_overview.py
@@ -14,9 +14,9 @@ WEIGHTS_FORMATS_OVERVIEW_PATH = (
 
 # defaults for transition period
 consumer_defaults = {
-    "ilastik": ["pytorch_state_dict", "onnx", "pytorch_script"],
+    "ilastik": ["pytorch_state_dict", "onnx", "torchscript"],
     "zero": ["keras_hdf5"],
-    "deepimagej": ["pytorch_script", "tensorflow_saved_model_bundle"],
+    "deepimagej": ["tensorflow_saved_model_bundle"],
     "imjoy": ["onnx"],
 }
 

--- a/scripts/generate_weight_formats_overview.py
+++ b/scripts/generate_weight_formats_overview.py
@@ -16,7 +16,7 @@ WEIGHTS_FORMATS_OVERVIEW_PATH = (
 consumer_defaults = {
     "ilastik": ["pytorch_state_dict", "onnx", "torchscript"],
     "zero": ["keras_hdf5"],
-    "deepimagej": ["tensorflow_saved_model_bundle"],
+    "deepimagej": ["torchscript", "tensorflow_saved_model_bundle"],
     "imjoy": ["onnx"],
 }
 

--- a/tests/test_format_version_conversion.py
+++ b/tests/test_format_version_conversion.py
@@ -21,6 +21,11 @@ def test_model_format_version_conversion(unet2d_nuclei_broad_before_latest, unet
         for out in expected["outputs"]:
             out["description"] = out["name"]
 
+    # ignore new maintainers field
+    if tuple(map(int, old_model_data["format_version"].split("."))) < (0, 4, 0):
+        expected.pop("maintainers", None)
+        actual.pop("maintainers", None)
+
     for key, item in expected.items():
         assert key in actual, key
         assert actual[key] == item, key

--- a/tests/test_schema_model.py
+++ b/tests/test_schema_model.py
@@ -72,7 +72,7 @@ def test_model_schema_accepts_run_mode(model_dict):
 
 @pytest.mark.parametrize(
     "format",
-    ["pytorch_state_dict", "pytorch_script", "keras_hdf5", "tensorflow_js", "tensorflow_saved_model_bundle", "onnx"],
+    ["pytorch_state_dict", "torchscript", "keras_hdf5", "tensorflow_js", "tensorflow_saved_model_bundle", "onnx"],
 )
 def test_model_schema_accepts_valid_weight_formats(model_dict, format):
     from bioimageio.spec.model.schema import Model


### PR DESCRIPTION
and fix unet2d_braod_nuclei version conversion tests (were broken by new maintainers field)