### PR TITLE
Warnings update

### DIFF
--- a/bioimageio/spec/model/v0_1/schema.py
+++ b/bioimageio/spec/model/v0_1/schema.py
@@ -28,7 +28,7 @@ class BaseSpec(BioImageIOSchema):
     name = fields.String(required=True)
     format_version = fields.String(required=True)
     description = fields.String(required=True)
-    cite = fields.Nested(CiteEntry(many=True), required=True)
+    cite = fields.List(fields.Nested(CiteEntry()), required=True)
     authors = fields.List(fields.String(required=True))
     documentation = fields.RelativeLocalPath(required=True)
     tags = fields.List(fields.String(), required=True)

--- a/bioimageio/spec/model/v0_4/schema.py
+++ b/bioimageio/spec/model/v0_4/schema.py
@@ -562,11 +562,11 @@ is in an unsupported format version. The current format version described here i
                     ),
                 )
                 if weights_entry.tensorflow_version is missing_:
-                    # todo: raise ValidationError (allow -> require)?
-                    warnings.warn(f"missing 'tensorflow_version' entry for weights format {weights_format}")
+                    # todo: raise ValidationError instead?
+                    self.warn(f"weights[{weights_format}]", "missing 'tensorflow_version'")
 
             if weights_format == "onnx":
                 assert isinstance(weights_entry, raw_nodes.OnnxWeightsEntry)
                 if weights_entry.opset_version is missing_:
-                    # todo: raise ValidationError?
-                    warnings.warn(f"missing 'opset_version' entry for weights format {weights_format}")
+                    # todo: raise ValidationError instead?
+                    self.warn(f"weights[{weights_format}]", "missing 'opset_version'")

--- a/bioimageio/spec/rdf/v0_2/schema.py
+++ b/bioimageio/spec/rdf/v0_2/schema.py
@@ -189,10 +189,7 @@ E.g. the citation for the model architecture and/or the training data used."""
             self.warn("license", f"{value} is not a recognized SPDX license identifier. See https://spdx.org/licenses/")
         else:
             if license_info.get("isDeprecatedLicenseId", False):
-                self.warn("license", f"{value} ({license_info['name']}) is deprecated")
-
-            if not license_info.get("isOsiApproved", False):
-                self.warn("license", f"{value} ({license_info['name']}) is not approved by OSI")
+                self.warn("license", f"{value} ({license_info['name']}) is deprecated.")
 
             if not license_info.get("isFsfLibre", False):
                 self.warn("license", f"{value} ({license_info['name']}) is not FSF Free/libre.")

--- a/bioimageio/spec/shared/fields.py
+++ b/bioimageio/spec/shared/fields.py
@@ -177,6 +177,12 @@ class Nested(DocumentedField, marshmallow_fields.Nested):
         repeat_type_name = self.type_name if self.bioimageio_description else ""
         self.bioimageio_description += f" {repeat_type_name} is a Dict with the following keys:"
 
+    def _deserialize(self, value, attr, data, partial=None, **kwargs):
+        if not isinstance(value, dict):
+            raise ValidationError(f"Expected dictionary, but got {type(value).__name__}.")
+
+        return super()._deserialize(value, attr, data, partial, **kwargs)
+
 
 class Raw(DocumentedField, marshmallow_fields.Raw):
     pass

--- a/bioimageio/spec/shared/schema.py
+++ b/bioimageio/spec/shared/schema.py
@@ -35,7 +35,8 @@ class SharedBioImageIOSchema(Schema):
 
     def warn(self, field: str, msg: str):
         """warn about a field with a ValidationWarning"""
-        field_instance = self.fields[field]
+        simple_field_name = field.split("[")[0]  # field may include [idx] or [key]
+        field_instance = self.fields[simple_field_name]
         assert ":" not in field
         assert " " not in field
         # todo: add spec trail to field

--- a/tests/test_sub_schemas.py
+++ b/tests/test_sub_schemas.py
@@ -16,6 +16,10 @@ def test_cite_entry():
 
 
 def test_cite_field_option1():
+    """only way we allow to specify listed, nested schemas.
+
+    Limitation to allow better exception and warning messages and make the code in general more concise.
+    """
     from bioimageio.spec.rdf.schema import CiteEntry
 
     data = [
@@ -30,20 +34,21 @@ def test_cite_field_option1():
     cite_field.deserialize(data)
 
 
-def test_cite_field_option2():
-    from bioimageio.spec.rdf.schema import CiteEntry
-
-    data = [
-        {
-            "text": "Title",
-            "doi": "https://doi.org/10.1109/5.771073",
-            "url": "https://ieeexplore.ieee.org/document/771073",
-        }
-    ] * 2
-
-    cite_field = fields.Nested(CiteEntry(many=True), required=True)
-    out = cite_field.deserialize(data)
-    assert len(out) == 2
+# we (arbitrarily) don't allow this. Test for reference only. see fields.Nested for details
+# def test_cite_field_option2():
+#     from bioimageio.spec.rdf.schema import CiteEntry
+#
+#     data = [
+#         {
+#             "text": "Title",
+#             "doi": "https://doi.org/10.1109/5.771073",
+#             "url": "https://ieeexplore.ieee.org/document/771073",
+#         }
+#     ] * 2
+#
+#     cite_field = fields.Nested(CiteEntry(many=True), required=True)
+#     out = cite_field.deserialize(data)
+#     assert len(out) == 2
 
 
 # we (arbitrarily) don't allow this. Test for reference only. see fields.Nested for details

--- a/tests/test_validation_errors.py
+++ b/tests/test_validation_errors.py
@@ -1,0 +1,14 @@
+"""check for meaningful validation errors for various invalid input"""
+
+
+def test_list_instead_of_nested_schema(unet2d_nuclei_broad_latest):
+    from bioimageio.spec.commands import validate
+
+    data = unet2d_nuclei_broad_latest
+    # set wrong run_mode (list)
+    data["run_mode"] = [{"name": "something"}]
+
+    error = validate(data)["error"]
+    print(error)
+    assert len(error) == 1
+    assert error["run_mode"] == ["Expected dictionary, but got list."]


### PR DESCRIPTION
- better validation error on attempt of deserializing a sub schema with anything other than a dict.
- warn about missing tensorflow_version and opset_version
- don't warn about OSI approval