### PR TITLE
Dump unknown for attachments and collection entries

### DIFF
--- a/bioimageio/spec/collection/v0_2/schema.py
+++ b/bioimageio/spec/collection/v0_2/schema.py
@@ -1,8 +1,6 @@
-from marshmallow import INCLUDE
-
 from bioimageio.spec.rdf.v0_2.schema import RDF
 from bioimageio.spec.shared import fields
-from bioimageio.spec.shared.schema import SharedBioImageIOSchema
+from bioimageio.spec.shared.schema import SharedBioImageIOSchema, WithUnknown
 from . import raw_nodes
 
 
@@ -10,10 +8,7 @@ class _BioImageIOSchema(SharedBioImageIOSchema):
     raw_nodes = raw_nodes
 
 
-class CollectionEntry(_BioImageIOSchema):
-    class Meta:
-        unknown = INCLUDE
-
+class CollectionEntry(_BioImageIOSchema, WithUnknown):
     id_ = fields.String(required=True, data_key="id")
     source = fields.URL(required=True)
     links = fields.List(fields.String())

--- a/bioimageio/spec/model/v0_4/schema.py
+++ b/bioimageio/spec/model/v0_4/schema.py
@@ -1,7 +1,7 @@
 import typing
 from copy import deepcopy
 
-from marshmallow import INCLUDE, RAISE, ValidationError, missing as missing_, pre_load, validates, validates_schema
+from marshmallow import RAISE, ValidationError, missing as missing_, pre_load, validates, validates_schema
 
 from bioimageio.spec.model.v0_3.schema import (
     KerasHdf5WeightsEntry,
@@ -18,7 +18,12 @@ from bioimageio.spec.rdf import v0_2 as rdf
 from bioimageio.spec.rdf.v0_2.schema import Author
 from bioimageio.spec.shared import LICENSES, field_validators, fields
 from bioimageio.spec.shared.common import get_args, get_args_flat
-from bioimageio.spec.shared.schema import ImplicitOutputShape, ParametrizedInputShape, SharedBioImageIOSchema
+from bioimageio.spec.shared.schema import (
+    ImplicitOutputShape,
+    ParametrizedInputShape,
+    SharedBioImageIOSchema,
+    WithUnknown,
+)
 from . import raw_nodes
 
 CiteEntry = rdf.schema.CiteEntry
@@ -28,10 +33,7 @@ class _BioImageIOSchema(SharedBioImageIOSchema):
     raw_nodes = raw_nodes
 
 
-class Attachments(_BioImageIOSchema):
-    class Meta:
-        unknown = INCLUDE
-
+class Attachments(_BioImageIOSchema, WithUnknown):
     files = fields.List(
         fields.Union([fields.URI(), fields.RelativeLocalPath()]),
         bioimageio_description="File attachments; included when packaging the model.",

--- a/bioimageio/spec/shared/schema.py
+++ b/bioimageio/spec/shared/schema.py
@@ -2,7 +2,7 @@ import warnings
 from types import ModuleType
 from typing import ClassVar, List
 
-from marshmallow import Schema, ValidationError, post_load, validates, validates_schema
+from marshmallow import INCLUDE, Schema, ValidationError, post_dump, post_load, validates, validates_schema
 
 from bioimageio.spec.shared import fields
 from . import raw_nodes
@@ -53,6 +53,20 @@ class SharedProcessingSchema(Schema):
     and they will be rendered in the documentation."""
 
     bioimageio_description: ClassVar[str]
+
+
+class WithUnknown(SharedBioImageIOSchema):
+    """allows to keep unknown fields on load and dump them the 'unknown' attribute of the data to serialize"""
+
+    class Meta:
+        unknown = INCLUDE
+
+    @post_dump(pass_original=True)
+    def keep_unknowns(self, output, orig, **kwargs):
+        assert hasattr(orig, "unknown")
+        out_w_unknown = dict(orig.unknown)
+        out_w_unknown.update(output)
+        return out_w_unknown
 
 
 class Dependencies(SharedBioImageIOSchema):

--- a/tests/test_dump_spec.py
+++ b/tests/test_dump_spec.py
@@ -14,3 +14,23 @@ def test_spec_round_trip(unet2d_nuclei_broad_any_minor):
 
     raw_model_from_serialized = load_raw_resource_description(serialized)
     assert raw_model_from_serialized == raw_model
+
+
+def test_spec_round_trip_w_attachments(unet2d_nuclei_broad_latest):
+    from bioimageio.spec import load_raw_resource_description, serialize_raw_resource_description_to_dict
+
+    data = unet2d_nuclei_broad_latest
+    # monkeypatch: yaml.load already converts timestamp to datetime.datetime, while we serialize it to ISO 8601
+    if "timestamp" in data:
+        data["timestamp"] = data["timestamp"].isoformat()
+
+    data["attachments"] = {"files": ["some_file.ext"], "another_unknown_attachment": ["sub", "whatever", {"weird": 10}]}
+
+    raw_model = load_raw_resource_description(data)
+
+    serialized = serialize_raw_resource_description_to_dict(raw_model)
+    assert isinstance(serialized, dict)
+    assert serialized == data
+
+    raw_model_from_serialized = load_raw_resource_description(serialized)
+    assert raw_model_from_serialized == raw_model


### PR DESCRIPTION
Currently loading attachments and collection entries will keep unknown fields in the respective node's `unknown` attribute, but on dumping that data is lost. This PR fixes this.