### PR TITLE
Fix collection spec validation

### DIFF
--- a/bioimageio/spec/__main__.py
+++ b/bioimageio/spec/__main__.py
@@ -44,6 +44,11 @@ def validate(
     else:
         print(f"No validation errors for {summary['name']}")
         ret_code = 0
+
+    if summary["warnings"]:
+        print(f"Validation Warnings for {summary['name']}:")
+        pprint(summary["warnings"])
+
     sys.exit(ret_code)
 
 

--- a/bioimageio/spec/collection/v0_2/raw_nodes.py
+++ b/bioimageio/spec/collection/v0_2/raw_nodes.py
@@ -23,13 +23,13 @@ except ImportError:
 @dataclass
 class CollectionEntry(RawNode):
     source: URI = missing
-    id_: str = missing
+    id: str = missing
     links: Union[_Missing, List[str]] = missing
     unknown: Dict[str, Any] = missing
 
     def __init__(self, source=missing, id_=missing, links=missing, **unknown):
         self.source = source
-        self.id_ = id_
+        self.id = id_
         self.links = links
         self.unknown = unknown
         super().__init__()

--- a/bioimageio/spec/shared/common.py
+++ b/bioimageio/spec/shared/common.py
@@ -27,7 +27,7 @@ class ValidationWarning(UserWarning):
     """a warning category to warn with during RDF validation"""
 
     @staticmethod
-    def get_warning_summary(val_warns: Sequence[warnings.WarningMessage]):
+    def get_warning_summary(val_warns: Sequence[warnings.WarningMessage]) -> dict:
         """Summarize warning messsages of the ValidationWarning category"""
 
         def add_to_summary(s, keys, msg):
@@ -46,12 +46,12 @@ class ValidationWarning(UserWarning):
 
             if idx is not None:
                 if idx not in s:
-                    s[idx] = {} if keys else msg
+                    s[idx] = {} if keys else {"warning": msg}
 
                 s = s[idx]
 
             if keys:
-                assert isinstance(s, dict)
+                assert isinstance(s, dict), (keys, s)
                 add_to_summary(s, keys, msg)
 
         summary: dict = {}


### PR DESCRIPTION
example output:
```
$> bioimageio validate https://raw.githubusercontent.com/ilastik/bioimage-io-models/datasets/collection.yaml
bioimageio.spec 0.4.1post1
implementing:
	collection RDF 0.2.1
	general RDF 0.2.1
	model RDF 0.4.1
Error in Ilastik Collection:
{'dataset': {0: {'format_version': ['Missing data for required field.']},
             1: {'format_version': ['Missing data for required field.']},
             2: {'format_version': ['Missing data for required field.']}}}
Validation Warnings for Ilastik Collection:
{'dataset': {0: {'type': '(id=covid_if_training_data) Unrecognized type '
                         'dataset. Validating as rdf.',
                 'warning': '(id=covid_if_training_data) Failed to interpret '
                            'source as rdf source; error '},
             1: {'type': '(id=cremi_training_data) Unrecognized type dataset. '
                         'Validating as rdf.',
                 'warning': '(id=cremi_training_data) Failed to interpret '
                            'source as rdf source; error '},
             2: {'type': '(id=stradist_dsb_training_data) Unrecognized type '
                         'dataset. Validating as rdf.',
                 'warning': '(id=stradist_dsb_training_data) Failed to '
                            'interpret source as rdf source; error '}}}

Process finished with exit code 1

```