### PR TITLE
Various fixes for general RDF and Collection RDF

### DIFF
--- a/bioimageio/spec/collection/v0_2/raw_nodes.py
+++ b/bioimageio/spec/collection/v0_2/raw_nodes.py
@@ -24,13 +24,11 @@ except ImportError:
 class CollectionEntry(RawNode):
     source: URI = missing
     id: str = missing
-    links: Union[_Missing, List[str]] = missing
     unknown: Dict[str, Any] = missing
 
-    def __init__(self, source=missing, id_=missing, links=missing, **unknown):
+    def __init__(self, source=missing, id_=missing, **unknown):
         self.source = source
         self.id = id_
-        self.links = links
         self.unknown = unknown
         super().__init__()
 

--- a/bioimageio/spec/collection/v0_2/raw_nodes.py
+++ b/bioimageio/spec/collection/v0_2/raw_nodes.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Union
 from marshmallow import missing
 from marshmallow.utils import _Missing
 
+from bioimageio.spec import model as model_spec
 from bioimageio.spec.rdf.v0_2.raw_nodes import FormatVersion, RDF
 from bioimageio.spec.shared.raw_nodes import RawNode, URI
 
@@ -36,7 +37,9 @@ class CollectionEntry(RawNode):
 @dataclass
 class Collection(RDF):
     application: Union[_Missing, List[Union[CollectionEntry, RDF]]] = missing
-    collection: Union[_Missing, List[Union[CollectionEntry, RDF]]] = missing
-    model: Union[_Missing, List[Union[CollectionEntry, RDF]]] = missing
+    # collection: Union[_Missing, List[Union[CollectionEntry, "Collection"]]] = missing
+    model: Union[
+        _Missing, List[Union[CollectionEntry, model_spec.v0_3.raw_nodes.Model, model_spec.v0_4.raw_nodes.Model]]
+    ] = missing
     dataset: Union[_Missing, List[Union[CollectionEntry, RDF]]] = missing
     notebook: Union[_Missing, List[Union[CollectionEntry, RDF]]] = missing

--- a/bioimageio/spec/collection/v0_2/schema.py
+++ b/bioimageio/spec/collection/v0_2/schema.py
@@ -1,6 +1,7 @@
 from marshmallow import RAISE
 
 from bioimageio.spec.rdf.v0_2.schema import RDF
+from bioimageio.spec import model
 from bioimageio.spec.shared import fields
 from bioimageio.spec.shared.schema import SharedBioImageIOSchema, WithUnknown
 from . import raw_nodes
@@ -32,7 +33,15 @@ The collection RDF YAML file contains mandatory and optional fields. In the foll
 _optional*_ with an asterisk indicates the field is optional depending on the value in another field.
 """
     application = fields.List(fields.Union([fields.Nested(CollectionEntry()), fields.Nested(RDF())]))
-    collection = fields.List(fields.Union([fields.Nested(CollectionEntry()), fields.Nested(RDF())]))
-    model = fields.List(fields.Union([fields.Nested(CollectionEntry()), fields.Nested(RDF())]))
+    # collection = fields.List(fields.Union([fields.Nested(CollectionEntry()), fields.Nested(lambda: Collection())]))
+    model = fields.List(
+        fields.Union(
+            [
+                fields.Nested(CollectionEntry()),
+                fields.Nested(model.v0_4.schema.Model()),
+                fields.Nested(model.v0_3.schema.Model()),
+            ]
+        )
+    )
     dataset = fields.List(fields.Union([fields.Nested(CollectionEntry()), fields.Nested(RDF())]))
     notebook = fields.List(fields.Union([fields.Nested(CollectionEntry()), fields.Nested(RDF())]))

--- a/bioimageio/spec/collection/v0_2/schema.py
+++ b/bioimageio/spec/collection/v0_2/schema.py
@@ -18,7 +18,6 @@ class _BioImageIOSchema(SharedBioImageIOSchema):
 class CollectionEntry(_BioImageIOSchema, WithUnknown):
     id_ = fields.String(required=True, data_key="id")
     source = fields.URL(required=True)
-    links = fields.List(fields.String())
 
 
 class Collection(_BioImageIOSchema, RDF):

--- a/bioimageio/spec/commands.py
+++ b/bioimageio/spec/commands.py
@@ -103,7 +103,7 @@ def validate(
 
                             nested_errors[inner_category][inner_idx] = inner_summary["error"]
 
-                        for k, v in inner_summary["warnings"].items():
+                        for k, v in inner_summary.get("warnings", {}).items():
                             warnings.warn(
                                 f"{inner_category}[{inner_idx}]:{k}: (id={inner.id}) {v}", category=ValidationWarning
                             )

--- a/bioimageio/spec/commands.py
+++ b/bioimageio/spec/commands.py
@@ -77,25 +77,31 @@ def validate(
             if raw_rd is not None and raw_rd.type == "collection":
                 for inner_category in KNOWN_COLLECTION_CATEGORIES:
                     for inner_idx, inner in enumerate(getattr(raw_rd, inner_category, []) or []):
-                        try:
-                            # check if inner.source points to an rdf
+                        # inner is CollectionEntry or RDF
+                        inner_source = getattr(inner, "source", None)
+                        inner_id = getattr(inner, "id", None)
+
+                        rdf_data = {}
+                        if inner_id is None:
+                            inner_descr = f"name={getattr(inner, 'name', 'unknown')}"
+                        else:
+                            inner_descr = f"id={inner_id}"
+
                             try:
-                                rdf_data, source_name, root = resolve_rdf_source(inner.source)
+                                # check if inner.source points to an rdf
+                                rdf_data, source_name, root = resolve_rdf_source(inner_source)
                             except Exception as e:
                                 warnings.warn(
-                                    f"{inner_category}[{inner_idx}]: (id={inner.id}) Failed to interpret source as rdf source; error {e}",
+                                    f"{inner_category}[{inner_idx}]: ({inner_descr}) Failed to interpret source as rdf source; error {e}",
                                     category=ValidationWarning,
                                 )
-                                rdf_data = {}
+                                inner_summary: Dict[str, Any] = {"error": str(e)}
 
-                        except Exception as e:
-                            inner_summary: Dict[str, Any] = {"error": str(e)}
-                        else:
-                            # update rdf data with additional fields of the collection entry
-                            rdf_data.update(inner.unknown)
-                            inner_summary = validate(
-                                rdf_data, update_format=update_format, update_format_inner=update_format_inner
-                            )
+                        # update rdf data with additional fields of the collection entry
+                        rdf_data.update(getattr(inner, "unknown", {}))
+                        inner_summary = validate(
+                            rdf_data, update_format=update_format, update_format_inner=update_format_inner
+                        )
 
                         if inner_summary["error"]:
                             if inner_category not in nested_errors:
@@ -105,7 +111,7 @@ def validate(
 
                         for k, v in inner_summary.get("warnings", {}).items():
                             warnings.warn(
-                                f"{inner_category}[{inner_idx}]:{k}: (id={inner.id}) {v}", category=ValidationWarning
+                                f"{inner_category}[{inner_idx}]:{k}: ({inner_descr}) {v}", category=ValidationWarning
                             )
 
                 if nested_errors:

--- a/bioimageio/spec/rdf/v0_2/raw_nodes.py
+++ b/bioimageio/spec/rdf/v0_2/raw_nodes.py
@@ -82,6 +82,7 @@ class RDF(ResourceDescription):
     documentation: Path = missing
     format_version: FormatVersion = missing
     git_repo: Union[_Missing, str] = missing
+    icon: Union[_Missing, str] = missing
     license: Union[_Missing, str] = missing
     links: Union[_Missing, List[str]] = missing
     maintainers: Union[_Missing, List[Maintainer]] = missing

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ def test_cli_validate_model_url():
 
 
 def test_cli_validate_model_doi():
-    ret = subprocess.run(["bioimageio", "validate", "10.5072/zenodo.886788"])
+    ret = subprocess.run(["bioimageio", "validate", "10.5281/zenodo.5744489"])
     assert ret.returncode == 0
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -31,8 +31,7 @@ def test_validate_model_as_url():
 def test_validate_model_as_zenodo_sandbox_doi():
     from bioimageio.spec.commands import validate
 
-    doi = "10.5072/zenodo.886788"
-    assert not validate(doi, update_format=True, update_format_inner=False)["error"]
+    doi = "10.5281/zenodo.5744489"
     assert not validate(doi, update_format=False, update_format_inner=False)["error"]
 
 


### PR DESCRIPTION
-  fix `icon` field for RDF
- fix validation of collection (account for collection that are an RDF)
-  Collection `links` "moved" to unknown (no special need for it explicitly)
-  replace zenodo sandbox test doi with real doi