### PR TITLE
Fix doc generation

### DIFF
--- a/bioimageio/spec/model/v0_3/schema.py
+++ b/bioimageio/spec/model/v0_3/schema.py
@@ -642,7 +642,7 @@ is in an unsupported format version. The current format version described here i
         required=True,
         bioimageio_description="List of URIs or local relative paths to test inputs as described in inputs for "
         "**a single test case**. "
-        "This means if your model has more than one input, you should provide one URI for each input."
+        "This means if your model has more than one input, you should provide one URI for each input. "
         "Each test input should be a file with a ndarray in "
         "[numpy.lib file format](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html#module-numpy.lib.format)."
         "The extension must be '.npy'.",

--- a/bioimageio/spec/model/v0_4/schema.py
+++ b/bioimageio/spec/model/v0_4/schema.py
@@ -299,9 +299,9 @@ _optional*_ with an asterisk indicates the field is optional depending on the va
             ),
         ],
         required=True,
-        bioimageio_description="Relative path to file with additional documentation in markdown. This means: 1) only "
-        "relative file path is allowed 2) the file must be in markdown format with `.md` file name extension 3) URL is "
-        "not allowed. It is recommended to use `README.md` as the documentation name.",
+        bioimageio_description="Relative path or URL to file with additional documentation in markdown. "
+        "The file must be in markdown format with `.md` file name extension"
+        "It is recommended to use `README.md` as the documentation name.",
     )
 
     format_version = fields.String(
@@ -450,7 +450,7 @@ is in an unsupported format version. The current format version described here i
         fields.Union([fields.URI(), fields.RelativeLocalPath()]),
         validate=field_validators.Length(min=1),
         required=True,
-        bioimageio_description="Analog to to test_inputs.",
+        bioimageio_description="Analog to test_inputs.",
     )
 
     sample_inputs = fields.List(

--- a/bioimageio/spec/rdf/v0_2/schema.py
+++ b/bioimageio/spec/rdf/v0_2/schema.py
@@ -56,8 +56,10 @@ class Badge(_BioImageIOSchema):
 
 
 class CiteEntry(_BioImageIOSchema):
-    text = fields.String(required=True)
-    doi = fields.DOI(bioimageio_maybe_required=True)
+    text = fields.String(required=True, bioimageio_description="free text description")
+    doi = fields.DOI(
+        bioimageio_maybe_required=True, bioimageio_description="digital object identifier, see https://www.doi.org/"
+    )
     url = fields.String(bioimageio_maybe_required=True)  # todo: change to fields.URL
 
     @validates_schema


### PR DESCRIPTION
Noticed that the documentation field of the current [model RDF 0.4](https://github.com/bioimage-io/spec-bioimage-io/blob/46c889b3f4a795255c415e8f8348a957b825cdf5/model_spec_0_4.md) is missing...

I hope this and some other bugs like it are fixed now without having introduced others. The whole doc generation is ripe for a clean up, but I think for now it is at least not leaving anything out...