### PR TITLE
Warn about tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ bioimageio update-format <MY-MODEL-SOURCE> <OUTPUT-PATH>
 
 
 ## Changelog
+#### todo: bioimageio.spec 0.4.3post1
+  - changes to api:
+    - moved objects from bioimageio.spec.shared.utils to bioimageio.spec.shared\[.node_transformer\]
+
 #### bioimageio.spec 0.4.2post4
   - fixes to general RDF:
     - ignore value of field `root_path` if present in yaml. This field is used internally and always present in RDF nodes.

--- a/bioimageio/spec/collection/v0_2/utils.py
+++ b/bioimageio/spec/collection/v0_2/utils.py
@@ -14,7 +14,7 @@ def resolve_collection_entries(
     collection: raw_nodes.Collection, collection_id: Optional[str] = None
 ) -> List[Tuple[dict, Optional[str]]]:
     from bioimageio.spec import serialize_raw_resource_description_to_dict
-    from bioimageio.spec.shared.utils import resolve_rdf_source
+    from bioimageio.spec.shared import resolve_rdf_source
 
     ret = []
     seen_ids = set()

--- a/bioimageio/spec/io_.py
+++ b/bioimageio/spec/io_.py
@@ -13,7 +13,7 @@ from typing import Dict, IO, Optional, Sequence, Tuple, Union
 
 from marshmallow import missing
 
-from bioimageio.spec.shared import raw_nodes
+from bioimageio.spec.shared import RDF_NAMES, raw_nodes, resolve_rdf_source, resolve_rdf_source_and_type, resolve_source
 from bioimageio.spec.shared.common import (
     BIOIMAGEIO_CACHE_PATH,
     get_class_name_from_type,
@@ -22,18 +22,14 @@ from bioimageio.spec.shared.common import (
     get_latest_format_version_module,
     yaml,
 )
-from bioimageio.spec.shared.raw_nodes import ResourceDescription as RawResourceDescription
-from bioimageio.spec.shared.schema import SharedBioImageIOSchema
-from bioimageio.spec.shared.utils import (
+from bioimageio.spec.shared.node_transformer import (
     GenericRawNode,
     GenericRawRD,
     PathToRemoteUriTransformer,
-    RDF_NAMES,
     RawNodePackageTransformer,
-    resolve_rdf_source,
-    resolve_rdf_source_and_type,
-    resolve_source,
 )
+from bioimageio.spec.shared.raw_nodes import ResourceDescription as RawResourceDescription
+from bioimageio.spec.shared.schema import SharedBioImageIOSchema
 
 try:
     from typing import Protocol

--- a/bioimageio/spec/rdf/v0_2/schema.py
+++ b/bioimageio/spec/rdf/v0_2/schema.py
@@ -1,12 +1,13 @@
 from marshmallow import EXCLUDE, ValidationError, validates, validates_schema
 
-from bioimageio.spec.shared import LICENSES, field_validators, fields
-from bioimageio.spec.shared.common import (
+from bioimageio.spec.shared import (
     BIOIMAGEIO_SITE_CONFIG,
     BIOIMAGEIO_SITE_CONFIG_ERROR,
-    get_args,
-    get_patched_format_version,
+    LICENSES,
+    field_validators,
+    fields,
 )
+from bioimageio.spec.shared.common import get_args, get_patched_format_version
 from bioimageio.spec.shared.schema import SharedBioImageIOSchema, WithUnknown
 from bioimageio.spec.shared.utils import is_valid_orcid_id
 from . import raw_nodes

--- a/bioimageio/spec/rdf/v0_2/schema.py
+++ b/bioimageio/spec/rdf/v0_2/schema.py
@@ -1,7 +1,12 @@
 from marshmallow import EXCLUDE, ValidationError, validates, validates_schema
 
 from bioimageio.spec.shared import LICENSES, field_validators, fields
-from bioimageio.spec.shared.common import get_args, get_patched_format_version
+from bioimageio.spec.shared.common import (
+    BIOIMAGEIO_SITE_CONFIG,
+    BIOIMAGEIO_SITE_CONFIG_ERROR,
+    get_args,
+    get_patched_format_version,
+)
 from bioimageio.spec.shared.schema import SharedBioImageIOSchema, WithUnknown
 from bioimageio.spec.shared.utils import is_valid_orcid_id
 from . import raw_nodes
@@ -223,6 +228,29 @@ E.g. the citation for the model architecture and/or the training data used."""
     )
 
     tags = fields.List(fields.String(), bioimageio_description="A list of tags.")
+
+    @validates("tags")
+    def warn_about_tag_categories(self, value):
+        if BIOIMAGEIO_SITE_CONFIG is None:
+            error = BIOIMAGEIO_SITE_CONFIG_ERROR
+        else:
+            missing_categories = []
+            try:
+                categories = {
+                    c["type"]: c["tag_categories"] for c in BIOIMAGEIO_SITE_CONFIG["resource_categories"]
+                }.get(self.__class__.__name__.lower(), {})
+                for cat, entries in categories.items():
+                    if not any(e in value for e in entries):
+                        missing_categories.append(cat)
+            except Exception as e:
+                error = str(e)
+            else:
+                error = None
+                if missing_categories:
+                    self.warn("tags", f"Missing tags for categories: {missing_categories}")
+
+        if error is not None:
+            self.warn("tags", f"could not check tag categories ({error})")
 
     type = fields.String(required=True)
 

--- a/bioimageio/spec/shared/__init__.py
+++ b/bioimageio/spec/shared/__init__.py
@@ -2,12 +2,34 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Optional
 
 from . import fields, raw_nodes, schema
-from .common import get_args, yaml  # noqa
+from ._resolve_source import (
+    RDF_NAMES,
+    resolve_local_source,
+    resolve_rdf_source,
+    resolve_rdf_source_and_type,
+    resolve_source,
+    source_available,
+)
+from .common import BIOIMAGEIO_SITE_CONFIG_URL, get_args, yaml  # noqa
 
 _license_file = Path(__file__).parent.parent / "static" / "licenses.json"
 _license_data = json.loads(_license_file.read_text(encoding="utf-8"))
 
 LICENSES = {x["licenseId"]: x for x in _license_data["licenses"]}
 LICENSE_DATA_VERSION = _license_data["licenseListVersion"]
+
+
+try:
+    p = resolve_source(BIOIMAGEIO_SITE_CONFIG_URL)
+    with p.open() as f:
+        BIOIMAGEIO_SITE_CONFIG = json.load(f)
+
+    assert isinstance(BIOIMAGEIO_SITE_CONFIG, dict)
+except Exception as e:
+    BIOIMAGEIO_SITE_CONFIG = None
+    BIOIMAGEIO_SITE_CONFIG_ERROR: Optional[str] = str(e)
+else:
+    BIOIMAGEIO_SITE_CONFIG_ERROR = None

--- a/bioimageio/spec/shared/_resolve_source.py
+++ b/bioimageio/spec/shared/_resolve_source.py
@@ -11,8 +11,8 @@ from urllib.request import url2pathname
 
 from marshmallow import ValidationError
 
-from bioimageio.spec.shared import fields, raw_nodes, yaml
-from bioimageio.spec.shared.common import BIOIMAGEIO_CACHE_PATH
+from . import fields, raw_nodes
+from .common import BIOIMAGEIO_CACHE_PATH, yaml
 
 DOI_REGEX = r"^10[.][0-9]{4,9}\/[-._;()\/:A-Za-z0-9]+$"
 RDF_NAMES = ("rdf.yaml", "model.yaml")
@@ -258,9 +258,7 @@ def resolve_local_source(
     root_path: os.PathLike,
     output: typing.Optional[os.PathLike] = None,
 ) -> typing.Union[pathlib.Path, raw_nodes.URI]:
-    if isinstance(source, (tuple, list)):
-        return type(source)([resolve_local_source(s, root_path, output) for s in source])
-    elif isinstance(source, os.PathLike) or isinstance(source, str):
+    if isinstance(source, os.PathLike) or isinstance(source, str):
         try:  # source as path from cwd
             is_path_cwd = pathlib.Path(source).exists()
         except OSError:
@@ -296,7 +294,7 @@ def resolve_local_source(
 
     assert isinstance(uri, raw_nodes.URI), uri
     if uri.scheme == "file":
-        local_path_or_remote_uri = pathlib.Path(url2pathname(uri.path))
+        local_path_or_remote_uri: typing.Union[pathlib.Path, raw_nodes.URI] = pathlib.Path(url2pathname(uri.path))
     elif uri.scheme in ("https", "https"):
         local_path_or_remote_uri = uri
     else:

--- a/bioimageio/spec/shared/common.py
+++ b/bioimageio/spec/shared/common.py
@@ -1,11 +1,8 @@
-import json
 import os
 import pathlib
 import tempfile
 import warnings
 from typing import Generic, Optional, Sequence
-
-from .utils import resolve_source
 
 try:
     from typing import Literal, get_args, get_origin, Protocol
@@ -41,19 +38,6 @@ BIOIMAGEIO_CACHE_PATH = pathlib.Path(
 )
 
 BIOIMAGEIO_SITE_CONFIG_URL = "https://raw.githubusercontent.com/bioimage-io/bioimage.io/main/site.config.json"
-
-
-try:
-    p = resolve_source(BIOIMAGEIO_SITE_CONFIG_URL)
-    with p.open() as f:
-        BIOIMAGEIO_SITE_CONFIG = json.load(f)
-
-    assert isinstance(BIOIMAGEIO_SITE_CONFIG, dict)
-except Exception as e:
-    BIOIMAGEIO_SITE_CONFIG = None
-    BIOIMAGEIO_SITE_CONFIG_ERROR = str(e)
-else:
-    BIOIMAGEIO_SITE_CONFIG_ERROR = None
 
 
 class ValidationWarning(UserWarning):

--- a/bioimageio/spec/shared/common.py
+++ b/bioimageio/spec/shared/common.py
@@ -1,8 +1,11 @@
+import json
 import os
 import pathlib
 import tempfile
 import warnings
 from typing import Generic, Optional, Sequence
+
+from .utils import resolve_source
 
 try:
     from typing import Literal, get_args, get_origin, Protocol
@@ -36,6 +39,21 @@ else:
 BIOIMAGEIO_CACHE_PATH = pathlib.Path(
     os.getenv("BIOIMAGEIO_CACHE_PATH", pathlib.Path(tempfile.gettempdir()) / "bioimageio_cache")
 )
+
+BIOIMAGEIO_SITE_CONFIG_URL = "https://raw.githubusercontent.com/bioimage-io/bioimage.io/main/site.config.json"
+
+
+try:
+    p = resolve_source(BIOIMAGEIO_SITE_CONFIG_URL)
+    with p.open() as f:
+        BIOIMAGEIO_SITE_CONFIG = json.load(f)
+
+    assert isinstance(BIOIMAGEIO_SITE_CONFIG, dict)
+except Exception as e:
+    BIOIMAGEIO_SITE_CONFIG = None
+    BIOIMAGEIO_SITE_CONFIG_ERROR = str(e)
+else:
+    BIOIMAGEIO_SITE_CONFIG_ERROR = None
 
 
 class ValidationWarning(UserWarning):

--- a/bioimageio/spec/shared/node_transformer.py
+++ b/bioimageio/spec/shared/node_transformer.py
@@ -6,8 +6,8 @@ import typing
 from marshmallow import missing
 from marshmallow.utils import _Missing
 
-from bioimageio.spec.shared import raw_nodes
-from ._resolve_source import resolve_source
+from . import raw_nodes
+from ._resolve_source import resolve_source as _resolve_source
 
 try:
     from typing import Literal
@@ -179,14 +179,14 @@ class UriNodeTransformer(NodeTransformer):
         self.root_path = pathlib.Path(root_path).resolve()
 
     def transform_URI(self, node: raw_nodes.URI) -> pathlib.Path:
-        local_path = resolve_source(node, root_path=self.root_path)
+        local_path = _resolve_source(node, root_path=self.root_path)
         return local_path
 
     def transform_ImportableSourceFile(
         self, node: raw_nodes.ImportableSourceFile
     ) -> raw_nodes.ResolvedImportableSourceFile:
         return raw_nodes.ResolvedImportableSourceFile(
-            source_file=resolve_source(node.source_file, self.root_path), callable_name=node.callable_name
+            source_file=_resolve_source(node.source_file, self.root_path), callable_name=node.callable_name
         )
 
     def transform_ImportableModule(self, node: raw_nodes.ImportableModule) -> raw_nodes.LocalImportableModule:

--- a/bioimageio/spec/shared/utils/__init__.py
+++ b/bioimageio/spec/shared/utils/__init__.py
@@ -1,21 +1,2 @@
 from ._docs import get_ref_url, snake_case_to_camel_case
-from ._node_transformer import (
-    GenericRawNode,
-    GenericRawRD,
-    GenericResolvedNode,
-    NodeTransformer,
-    NodeVisitor,
-    PathToRemoteUriTransformer,
-    RawNodePackageTransformer,
-    UriNodeTransformer,
-)
-from ._resolve_source import (
-    RDF_NAMES,
-    resolve_local_source,
-    resolve_local_sources,
-    resolve_rdf_source,
-    resolve_rdf_source_and_type,
-    resolve_source,
-    source_available,
-)
 from ._various import is_valid_orcid_id

--- a/tests/test_node_transformer.py
+++ b/tests/test_node_transformer.py
@@ -4,7 +4,8 @@ from typing import Any
 
 import pytest
 
-from bioimageio.spec.shared import raw_nodes, utils
+from bioimageio.spec.shared import raw_nodes
+from bioimageio.spec.shared.node_transformer import NodeTransformer, NodeVisitor, iter_fields
 
 
 @dataclass
@@ -15,7 +16,7 @@ class MyNode(raw_nodes.RawNode):
 
 def test_iter_fields():
     entry = MyNode("a", 42)
-    assert [("field_a", "a"), ("field_b", 42)] == list(utils._node_transformer.iter_fields(entry))
+    assert [("field_a", "a"), ("field_b", 42)] == list(iter_fields(entry))
 
 
 @dataclass
@@ -41,11 +42,11 @@ class TestNodeVisitor:
         )
 
     def test_node(self, tree):
-        visitor = utils.NodeVisitor()
+        visitor = NodeVisitor()
         visitor.visit(tree)
 
     def test_node_transform(self, tree):
-        class MyTransformer(utils.NodeTransformer):
+        class MyTransformer(NodeTransformer):
             def transform_URL(self, node):
                 return Content(f"content of url {node.url}")
 
@@ -56,7 +57,7 @@ class TestNodeVisitor:
 
 
 def test_resolve_remote_relative_path():
-    from bioimageio.spec.shared.utils import PathToRemoteUriTransformer
+    from bioimageio.spec.shared.node_transformer import PathToRemoteUriTransformer
 
     remote_rdf = raw_nodes.URI(
         "https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/models/"


### PR DESCRIPTION
fixes #315

if possible check the website config for tag categories and warn if tag categories are missing in the tags specified.

Unfortunately there were some bad (near cyclic) imports in bioimageio.spec.shared.utils from bioimageio.spec.shared. This PR also cleans that up, which breaks a few imports in core (some objects have moved from bioimageio.spec.shared.utils to bioimageio.spec.shared\[.node_transformer\] ). fix in core: https://github.com/bioimage-io/core-bioimage-io-python/pull/227

