### PR TITLE
Avoid partially downloaded files

### DIFF
--- a/bioimageio/spec/rdf/v0_2/schema.py
+++ b/bioimageio/spec/rdf/v0_2/schema.py
@@ -239,7 +239,7 @@ E.g. the citation for the model architecture and/or the training data used."""
             missing_categories = []
             try:
                 categories = {
-                    c["type"]: c["tag_categories"] for c in BIOIMAGEIO_SITE_CONFIG["resource_categories"]
+                    c["type"]: c.get("tag_categories", {}) for c in BIOIMAGEIO_SITE_CONFIG["resource_categories"]
                 }.get(self.__class__.__name__.lower(), {})
                 for cat, entries in categories.items():
                     if not any(e in value for e in entries):

--- a/bioimageio/spec/shared/_resolve_source.py
+++ b/bioimageio/spec/shared/_resolve_source.py
@@ -340,11 +340,13 @@ def _download_url(uri: raw_nodes.URI, output: typing.Optional[os.PathLike] = Non
             total_size = int(r.headers.get("content-length", 0))
             block_size = 1024  # 1 Kibibyte
             t = tqdm(total=total_size, unit="iB", unit_scale=True, desc=local_path.name)
-            with local_path.open("wb") as f:
+            tmp_path = local_path.with_suffix(f"{local_path.suffix}.part")
+            with tmp_path.open("wb") as f:
                 for data in r.iter_content(block_size):
                     t.update(len(data))
                     f.write(data)
             t.close()
+            shutil.move(str(tmp_path), str(local_path))
             if total_size != 0 and t.n != total_size:
                 # todo: check more carefully and raise on real issue
                 warnings.warn(f"Download ({t.n}) does not have expected size ({total_size}).")


### PR DESCRIPTION
... by downloading to .part file first.

Also this PR removes warnings for resource types which have no tag categories defined.