### PR TITLE
resolve ids from BIOIMAGEIO_COLLECTION

### DIFF
--- a/bioimageio/spec/shared/__init__.py
+++ b/bioimageio/spec/shared/__init__.py
@@ -2,33 +2,24 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Optional
 
 from ._resolve_source import (
+    BIOIMAGEIO_COLLECTION,
+    BIOIMAGEIO_COLLECTION_ERROR,
+    BIOIMAGEIO_SITE_CONFIG,
+    BIOIMAGEIO_SITE_CONFIG_ERROR,
     RDF_NAMES,
+    _resolve_json_from_url,
     resolve_local_source,
     resolve_rdf_source,
     resolve_rdf_source_and_type,
     resolve_source,
     source_available,
 )
-from .common import BIOIMAGEIO_SITE_CONFIG_URL, get_args, yaml  # noqa
+from .common import get_args, yaml  # noqa
 
 _license_file = Path(__file__).parent.parent / "static" / "licenses.json"
 _license_data = json.loads(_license_file.read_text(encoding="utf-8"))
 
 LICENSES = {x["licenseId"]: x for x in _license_data["licenses"]}
 LICENSE_DATA_VERSION = _license_data["licenseListVersion"]
-
-
-try:
-    p = resolve_source(BIOIMAGEIO_SITE_CONFIG_URL)
-    with p.open() as f:
-        BIOIMAGEIO_SITE_CONFIG = json.load(f)
-
-    assert isinstance(BIOIMAGEIO_SITE_CONFIG, dict)
-except Exception as e:
-    BIOIMAGEIO_SITE_CONFIG = None
-    BIOIMAGEIO_SITE_CONFIG_ERROR: Optional[str] = str(e)
-else:
-    BIOIMAGEIO_SITE_CONFIG_ERROR = None

--- a/bioimageio/spec/shared/_resolve_source.py
+++ b/bioimageio/spec/shared/_resolve_source.py
@@ -1,3 +1,4 @@
+import json
 import os
 import pathlib
 import re
@@ -7,15 +8,19 @@ import warnings
 import zipfile
 from functools import singledispatch
 from io import BytesIO, StringIO
-from urllib.request import url2pathname
+from urllib.request import url2pathname, urlopen
 
 from marshmallow import ValidationError
 
 from . import fields, raw_nodes
-from .common import BIOIMAGEIO_CACHE_PATH, yaml
-
-DOI_REGEX = r"^10[.][0-9]{4,9}\/[-._;()\/:A-Za-z0-9]+$"
-RDF_NAMES = ("rdf.yaml", "model.yaml")
+from .common import (
+    BIOIMAGEIO_CACHE_PATH,
+    BIOIMAGEIO_COLLECTION_URL,
+    BIOIMAGEIO_SITE_CONFIG_URL,
+    DOI_REGEX,
+    RDF_NAMES,
+    yaml,
+)
 
 
 def _is_path(s: typing.Any) -> bool:
@@ -60,10 +65,21 @@ def resolve_rdf_source(
         raise TypeError(source)
 
     if isinstance(source, str):
-        # source might be doi, url or file path -> resolve to pathlib.Path
-        if re.fullmatch(DOI_REGEX, source):  # turn doi into url
+        # source might be bioimageio id, doi, url or file path -> resolve to pathlib.Path
+
+        if BIOIMAGEIO_COLLECTION is None:
+            bioimageio_rdf_source = None
+        else:
+            bioimageio_rdf_source = {
+                c.get("id", f"missind_id_{i}"): c.get("rdf_source")
+                for i, c in enumerate(BIOIMAGEIO_COLLECTION.get("collection", []))
+            }.get(source)
+
+        if bioimageio_rdf_source is not None:
+            # source is bioimageio id
+            source = bioimageio_rdf_source
+        elif re.fullmatch(DOI_REGEX, source):  # turn doi into url
             import requests  # not available in pyodide
-            from urllib.request import urlopen
 
             zenodo_prefix = "10.5281/zenodo."
             zenodo_record_api = "https://zenodo.org/api/records"
@@ -79,7 +95,20 @@ def resolve_rdf_source(
                 is_zenodo_doi = True
 
             if is_zenodo_doi:
+                # source is a doi pointing to a zenodo record;
+                # we'll expect an rdf.yaml file in that record and use it as source...
                 record_id = source[len(zenodo_prefix) :]
+                s_count = record_id.count("/")
+                if s_count:
+                    # record_id/record_version_id
+                    if s_count != 1:
+                        warnings.warn(
+                            f"Unexpected Zenodo record ids: {record_id}. "
+                            f"Expected <concept id> or <concept id>/<version id>."
+                        )
+
+                    record_id = record_id.split("/")[-1]
+
                 response = requests.get(f"{zenodo_record_api}/{record_id}")
                 if not response.ok:
                     raise RuntimeError(response.status_code)
@@ -331,7 +360,6 @@ def _download_url(uri: raw_nodes.URI, output: typing.Optional[os.PathLike] = Non
         from tqdm import tqdm  # not available in pyodide
 
         try:
-
             # download with tqdm adapted from:
             # https://github.com/shaypal5/tqdl/blob/189f7fd07f265d29af796bee28e0893e1396d237/tqdl/core.py
             # Streaming, so we can iterate over the response.
@@ -354,3 +382,32 @@ def _download_url(uri: raw_nodes.URI, output: typing.Optional[os.PathLike] = Non
             raise RuntimeError(f"Failed to download {uri} ({e})")
 
     return local_path
+
+
+T = typing.TypeVar("T")
+
+
+def _resolve_json_from_url(
+    url: str,
+    expected_type: typing.Union[typing.Type[dict], typing.Type[T]] = dict,
+    warning_msg: str = "Failed to fetch {url}: {error}",
+) -> typing.Tuple[typing.Optional[T], typing.Optional[str]]:
+    try:
+        p = resolve_source(url)
+        with p.open() as f:
+            data = json.load(f)
+
+        assert isinstance(data, expected_type)
+    except Exception as e:
+        data = None
+        error: typing.Optional[str] = str(e)
+        if warning_msg:
+            warnings.warn(warning_msg.format(url=url, error=error))
+    else:
+        error = None
+
+    return data, error
+
+
+BIOIMAGEIO_SITE_CONFIG, BIOIMAGEIO_SITE_CONFIG_ERROR = _resolve_json_from_url(BIOIMAGEIO_SITE_CONFIG_URL)
+BIOIMAGEIO_COLLECTION, BIOIMAGEIO_COLLECTION_ERROR = _resolve_json_from_url(BIOIMAGEIO_COLLECTION_URL)

--- a/bioimageio/spec/shared/_resolve_source.py
+++ b/bioimageio/spec/shared/_resolve_source.py
@@ -70,10 +70,11 @@ def resolve_rdf_source(
         if BIOIMAGEIO_COLLECTION is None:
             bioimageio_rdf_source = None
         else:
-            bioimageio_rdf_source = {
+            bioimageio_collection = {
                 c.get("id", f"missind_id_{i}"): c.get("rdf_source")
                 for i, c in enumerate(BIOIMAGEIO_COLLECTION.get("collection", []))
-            }.get(source)
+            }
+            bioimageio_rdf_source = bioimageio_collection.get(source) or bioimageio_collection.get(source + "/latest")
 
         if bioimageio_rdf_source is not None:
             # source is bioimageio id

--- a/bioimageio/spec/shared/common.py
+++ b/bioimageio/spec/shared/common.py
@@ -38,6 +38,11 @@ BIOIMAGEIO_CACHE_PATH = pathlib.Path(
 )
 
 BIOIMAGEIO_SITE_CONFIG_URL = "https://raw.githubusercontent.com/bioimage-io/bioimage.io/main/site.config.json"
+BIOIMAGEIO_COLLECTION_URL = "https://bioimage-io.github.io/collection-bioimage-io/collection.json"
+
+
+DOI_REGEX = r"^10[.][0-9]{4,9}\/[-._;()\/:A-Za-z0-9]+$"
+RDF_NAMES = ("rdf.yaml", "model.yaml")
 
 
 class ValidationWarning(UserWarning):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -54,6 +54,38 @@ def test_validate_model_as_zenodo_doi():
     assert validate(doi, update_format=True, update_format_inner=False)["error"]
 
 
+def test_validate_model_as_bioimageio_full_version_id_partner():
+    from bioimageio.spec.commands import validate
+
+    full_version_id = "ilastik/isbi2012_neuron_segmentation_challenge/latest"
+    summary = validate(full_version_id, update_format=False, update_format_inner=False)
+    assert summary["status"] == "passed", summary["error"]
+
+
+def test_validate_model_as_bioimageio_full_version_id_zenodo():
+    from bioimageio.spec.commands import validate
+
+    full_version_id = "10.5281/zenodo.5874741/5874742"
+    summary = validate(full_version_id, update_format=False, update_format_inner=False)
+    assert summary["status"] == "passed", summary["error"]
+
+
+def test_validate_model_as_bioimageio_resource_id_partner():
+    from bioimageio.spec.commands import validate
+
+    resource_id = "ilastik/isbi2012_neuron_segmentation_challenge"
+    summary = validate(resource_id, update_format=False, update_format_inner=False)
+    assert summary["status"] == "passed", summary["error"]
+
+
+def test_validate_model_as_bioimageio_resource_id_zenodo():
+    from bioimageio.spec.commands import validate
+
+    resource_id = "10.5281/zenodo.5874741"
+    summary = validate(resource_id, update_format=False, update_format_inner=False)
+    assert summary["status"] == "passed", summary["error"]
+
+
 def test_validate_model_as_bytes_io(unet2d_nuclei_broad_latest_path):
     from bioimageio.spec.commands import validate
 


### PR DESCRIPTION
this PR implements:
 - on import of bioimageio.spec we try to resolve the BioImage.IO collection.json that holds all available resources on bioimage.io.
 - with all available ids, we then resolve a given id in `load_raw_resource_description` (or any other func that takes an rdf source) to point to our updated rdf.yaml in  https://github.com/bioimage-io/collection-bioimage-io/tree/gh-pages/rdfs