### PR TITLE
replace distutils.version with packaging.version

### DIFF
--- a/bioimageio/spec/collection/v0_2/raw_nodes.py
+++ b/bioimageio/spec/collection/v0_2/raw_nodes.py
@@ -4,7 +4,7 @@ raw nodes are the deserialized equivalent to the content of any RDF.
 serialization and deserialization are defined in schema:
 RDF <--schema--> raw nodes
 """
-import distutils.version
+import packaging.version
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, NewType, Union
@@ -51,7 +51,7 @@ class Collection(RDF):
         format_version: FormatVersion,
         name: str,
         type: str = missing,
-        version: Union[_Missing, distutils.version.StrictVersion] = missing,
+        version: Union[_Missing, packaging.version.Version] = missing,
         # RDF
         attachments: Union[_Missing, Dict[str, Any]] = missing,
         authors: Union[_Missing, List[Author]] = missing,

--- a/bioimageio/spec/model/v0_3/raw_nodes.py
+++ b/bioimageio/spec/model/v0_3/raw_nodes.py
@@ -1,4 +1,4 @@
-import distutils.version
+import packaging.version
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -95,7 +95,7 @@ class _WeightsEntryBase(RawNode):
 @dataclass
 class KerasHdf5WeightsEntry(_WeightsEntryBase):
     weights_format_name = "Keras HDF5"
-    tensorflow_version: Union[_Missing, distutils.version.StrictVersion] = missing
+    tensorflow_version: Union[_Missing, packaging.version.Version] = missing
 
 
 @dataclass
@@ -117,13 +117,13 @@ class PytorchScriptWeightsEntry(_WeightsEntryBase):
 @dataclass
 class TensorflowJsWeightsEntry(_WeightsEntryBase):
     weights_format_name = "Tensorflow.js"
-    tensorflow_version: Union[_Missing, distutils.version.StrictVersion] = missing
+    tensorflow_version: Union[_Missing, packaging.version.Version] = missing
 
 
 @dataclass
 class TensorflowSavedModelBundleWeightsEntry(_WeightsEntryBase):
     weights_format_name = "Tensorflow Saved Model"
-    tensorflow_version: Union[_Missing, distutils.version.StrictVersion] = missing
+    tensorflow_version: Union[_Missing, packaging.version.Version] = missing
     # tag: Union[_Missing, str] = missing  # todo: do we need the tag??
 
 

--- a/bioimageio/spec/model/v0_3/schema.py
+++ b/bioimageio/spec/model/v0_3/schema.py
@@ -405,7 +405,7 @@ class _WeightsEntryBase(_BioImageIOSchema):
 class KerasHdf5WeightsEntry(_WeightsEntryBase):
     bioimageio_description = "Keras HDF5 weights format"
     weights_format = fields.String(validate=field_validators.Equal("keras_hdf5"), required=True, load_only=True)
-    tensorflow_version = fields.StrictVersion()
+    tensorflow_version = fields.Version()
 
 
 class OnnxWeightsEntry(_WeightsEntryBase):
@@ -427,7 +427,7 @@ class PytorchScriptWeightsEntry(_WeightsEntryBase):
 class TensorflowJsWeightsEntry(_WeightsEntryBase):
     bioimageio_description = "Tensorflow Javascript weights format"
     weights_format = fields.String(validate=field_validators.Equal("tensorflow_js"), required=True, load_only=True)
-    tensorflow_version = fields.StrictVersion()
+    tensorflow_version = fields.Version()
 
 
 class TensorflowSavedModelBundleWeightsEntry(_WeightsEntryBase):
@@ -435,7 +435,7 @@ class TensorflowSavedModelBundleWeightsEntry(_WeightsEntryBase):
     weights_format = fields.String(
         validate=field_validators.Equal("tensorflow_saved_model_bundle"), required=True, load_only=True
     )
-    tensorflow_version = fields.StrictVersion()
+    tensorflow_version = fields.Version()
 
 
 WeightsEntry = typing.Union[

--- a/bioimageio/spec/model/v0_4/raw_nodes.py
+++ b/bioimageio/spec/model/v0_4/raw_nodes.py
@@ -1,4 +1,4 @@
-import distutils.version
+import packaging.version
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -78,7 +78,7 @@ class PytorchStateDictWeightsEntry(_WeightsEntryBase):
     architecture: ImportableSource = missing
     architecture_sha256: Union[_Missing, str] = missing
     kwargs: Union[_Missing, Dict[str, Any]] = missing
-    pytorch_version: Union[_Missing, distutils.version.StrictVersion] = missing
+    pytorch_version: Union[_Missing, packaging.version.Version] = missing
 
 
 @dataclass
@@ -94,7 +94,7 @@ class TensorflowSavedModelBundleWeightsEntry(_WeightsEntryBase, TensorflowSavedM
 @dataclass
 class TorchscriptWeightsEntry(_WeightsEntryBase):
     weights_format_name = "Torchscript"
-    pytorch_version: Union[_Missing, distutils.version.StrictVersion] = missing
+    pytorch_version: Union[_Missing, packaging.version.Version] = missing
 
 
 WeightsEntry = Union[

--- a/bioimageio/spec/model/v0_4/schema.py
+++ b/bioimageio/spec/model/v0_4/schema.py
@@ -220,7 +220,7 @@ class PytorchStateDictWeightsEntry(_WeightsEntryBase):
     kwargs = fields.Kwargs(
         bioimageio_description="Keyword arguments for the implementation specified by `architecture`."
     )
-    pytorch_version = fields.StrictVersion()
+    pytorch_version = fields.Version()
 
     @validates_schema
     def sha_for_source_code_file(self, data, **kwargs):
@@ -253,7 +253,7 @@ class TorchscriptWeightsEntry(_WeightsEntryBase):
 
     bioimageio_description = "Torchscript weights format"
     weights_format = fields.String(validate=field_validators.Equal("torchscript"), required=True, load_only=True)
-    pytorch_version = fields.StrictVersion()
+    pytorch_version = fields.Version()
 
 
 WeightsEntry = typing.Union[

--- a/bioimageio/spec/rdf/v0_2/raw_nodes.py
+++ b/bioimageio/spec/rdf/v0_2/raw_nodes.py
@@ -5,7 +5,7 @@ serialization and deserialization are defined in schema:
 RDF <--schema--> raw nodes
 """
 import dataclasses
-import distutils.version
+import packaging.version
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
@@ -108,7 +108,7 @@ class RDF(ResourceDescription):
         format_version: FormatVersion,
         name: str,
         type: str = missing,
-        version: Union[_Missing, distutils.version.StrictVersion] = missing,
+        version: Union[_Missing, packaging.version.Version] = missing,
         # RDF
         attachments: Union[_Missing, Dict[str, Any]] = missing,
         authors: Union[_Missing, List[Author]] = missing,

--- a/bioimageio/spec/rdf/v0_2/schema.py
+++ b/bioimageio/spec/rdf/v0_2/schema.py
@@ -263,7 +263,7 @@ E.g. the citation for the model architecture and/or the training data used."""
         if value != schema_type:
             self.warn("type", f"Unrecognized type '{value}'. Validating as {schema_type}.")
 
-    version = fields.StrictVersion(
+    version = fields.Version(
         bioimageio_description="The version number of the model. The version number format must be a string in "
         "`MAJOR.MINOR.PATCH` format following the guidelines in Semantic Versioning 2.0.0 (see https://semver.org/), "
         "e.g. the initial version number should be `0.1.0`."

--- a/bioimageio/spec/shared/fields.py
+++ b/bioimageio/spec/shared/fields.py
@@ -1,6 +1,6 @@
 """fields to be used in the versioned schemas (may return shared raw nodes on `deserialize`"""
 import datetime
-import distutils.version
+import packaging.version
 import logging
 import pathlib
 import typing
@@ -513,7 +513,7 @@ class SHA256(String):
         return value_str
 
 
-class StrictVersion(String):
+class Version(String):
     def _deserialize(
         self,
         value: typing.Any,
@@ -521,7 +521,7 @@ class StrictVersion(String):
         data: typing.Optional[typing.Mapping[str, typing.Any]],
         **kwargs,
     ):
-        return distutils.version.StrictVersion(str(value))
+        return packaging.version.Version(str(value))
 
 
 class URI(String):

--- a/bioimageio/spec/shared/raw_nodes.py
+++ b/bioimageio/spec/shared/raw_nodes.py
@@ -5,7 +5,7 @@ serialization and deserialization are defined in schema:
 RDF <--schema--> raw nodes
 """
 import dataclasses
-import distutils.version
+import packaging.version
 import pathlib
 from dataclasses import dataclass
 from typing import ClassVar, List, Optional, Sequence, Union
@@ -47,7 +47,7 @@ class ResourceDescription(RawNode):
     format_version: str = missing
     name: str = missing
     type: str = missing
-    version: Union[_Missing, distutils.version.StrictVersion] = missing
+    version: Union[_Missing, packaging.version.Version] = missing
     root_path: pathlib.Path = pathlib.Path()  # note: `root_path` is not officially part of the spec,
     #                                                  but any RDF has it as it is the folder containing the rdf.yaml
 

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "marshmallow-union",
         "marshmallow>=3.6.0,<4.0",
         "numpy",
+        "packaging>=17.0",
         "requests;platform_system!='Emscripten'",
         "ruamel.yaml;platform_system!='Emscripten'",
         "tqdm;platform_system!='Emscripten'",


### PR DESCRIPTION
distutils.version is deprecated in py3.10. I would like to change it already as marshmallow did as well and there is a dependency issue in marshmallow that should be fixed with this PR as well (as we now ourselves depend on the packaging package).

This PR repalced `distutils.version.StrictVersion` with `packaging.version.Version` (see https://github.com/pypa/packaging/issues/520)

The initial issue caused by marshmallow came up for us here:
https://github.com/bioimage-io/collection-bioimage-io/pull/341 `ModuleNotFoundError: No module named 'packaging'`

The issue  is known in marshmallow: 
https://github.com/marshmallow-code/marshmallow/issues/1957

