### PR TITLE
Keep root path

### DIFF
--- a/bioimageio/spec/__init__.py
+++ b/bioimageio/spec/__init__.py
@@ -1,4 +1,9 @@
 from . import collection, model, rdf, shared
 from .commands import validate
-from .io_ import get_resource_package_content, load_raw_resource_description, serialize_raw_resource_description_to_dict
+from .io_ import (
+    get_resource_package_content,
+    load_raw_resource_description,
+    serialize_raw_resource_description,
+    serialize_raw_resource_description_to_dict,
+)
 from .v import __version__

--- a/bioimageio/spec/io_.py
+++ b/bioimageio/spec/io_.py
@@ -124,9 +124,8 @@ def extract_resource_package(
     return source, source_name, package_path
 
 
-def _replace_relative_paths_for_remote_source(
-    raw_rd: RawResourceDescription, root: Union[pathlib.Path, raw_nodes.URI, bytes]
-) -> RawResourceDescription:
+def _replace_relative_paths_for_remote_source(raw_rd: RawResourceDescription) -> RawResourceDescription:
+    root = raw_rd.root_path
     if isinstance(root, raw_nodes.URI):
         # for a remote source relative paths are invalid; replace all relative file paths in source with URLs
         raw_rd = PathToRemoteUriTransformer(remote_source=root).transform(raw_rd)
@@ -198,7 +197,7 @@ def load_raw_resource_description(
     raw_rd = schema.load(data)
     raw_rd.root_path = root
 
-    raw_rd = _replace_relative_paths_for_remote_source(raw_rd, raw_rd.root_path)
+    raw_rd = _replace_relative_paths_for_remote_source(raw_rd)
 
     return raw_rd
 

--- a/bioimageio/spec/shared/_resolve_source.py
+++ b/bioimageio/spec/shared/_resolve_source.py
@@ -25,6 +25,7 @@ from .common import (
     tqdm,
     yaml,
 )
+from .raw_nodes import URI
 
 
 def _is_path(s: typing.Any) -> bool:
@@ -55,7 +56,14 @@ def resolve_rdf_source(
         root: typing.Union[pathlib.Path, raw_nodes.URI, bytes] = source.parent
     elif isinstance(source, dict):
         source_name = f"{{name: {source.get('name', '<unknown>')}, ...}}"
-        root = pathlib.Path()
+        source = dict(source)
+        given_root = source.pop("root_path", pathlib.Path())
+        if _is_path(given_root):
+            root = pathlib.Path(given_root)
+        elif isinstance(given_root, str):
+            root = URI(uri_string=given_root)
+        else:
+            raise ValueError(f"Encountered invalid root {given_root}")
     elif isinstance(source, (str, bytes)):
         source_name = str(source[:120]) + "..."
         # string might be path or yaml string; for yaml string (or bytes) set root to cwd


### PR DESCRIPTION
allows to call `load_raw_resource_description` with a dict containting `root_path`