### PR TITLE
Resolve relative paths when loading a (raw) resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ bioimageio update-format <MY-MODEL-SOURCE> <OUTPUT-PATH>
 
 
 ## Changelog
-#### bioimageio.spec 0.4.6
+#### bioimageio.spec 0.5.4.post8
 - any field previously expecting a local relative path is now also accepting an absolute path
 - load_raw_resource_description returns a raw resource description which has no relative paths (any relative paths are converted to absolute paths).
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ bioimageio update-format <MY-MODEL-SOURCE> <OUTPUT-PATH>
 
 
 ## Changelog
+#### bioimageio.spec 0.4.6
+- any field previously expecting a local relative path is now also accepting an absolute path
+- load_raw_resource_description returns a raw resource description which has no relative paths (any relative paths are converted to absolute paths).
+
 #### bioimageio.spec 0.4.4post7
 - add command `commands.update_rdf()`/`update-rdf`(cli)
 

--- a/bioimageio/spec/VERSION
+++ b/bioimageio/spec/VERSION
@@ -1,3 +1,3 @@
 {
-    "version": "0.4.5post7"
+    "version": "0.4.5post8"
 }

--- a/bioimageio/spec/collection/v0_2/raw_nodes.py
+++ b/bioimageio/spec/collection/v0_2/raw_nodes.py
@@ -4,11 +4,12 @@ raw nodes are the deserialized equivalent to the content of any RDF.
 serialization and deserialization are defined in schema:
 RDF <--schema--> raw nodes
 """
-import packaging.version
-from dataclasses import dataclass, field
+import pathlib
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, NewType, Union
+from typing import Any, Dict, List, Union
 
+import packaging.version
 from marshmallow import missing
 from marshmallow.utils import _Missing
 
@@ -52,6 +53,7 @@ class Collection(RDF):
         name: str,
         type: str = missing,
         version: Union[_Missing, packaging.version.Version] = missing,
+        root_path: pathlib.Path = pathlib.Path(),
         # RDF
         attachments: Union[_Missing, Dict[str, Any]] = missing,
         authors: Union[_Missing, List[Author]] = missing,
@@ -90,6 +92,7 @@ class Collection(RDF):
             tags=tags,
             type=type,
             version=version,
+            root_path=root_path,
         )
         self.unknown = unknown or {}
         self.unknown.update(implicitly_unknown)

--- a/bioimageio/spec/collection/v0_2/raw_nodes.py
+++ b/bioimageio/spec/collection/v0_2/raw_nodes.py
@@ -43,7 +43,7 @@ class CollectionEntry(RawNode):
 @dataclass
 class Collection(RDF):
     collection: List[CollectionEntry] = missing
-
+    unknown: Dict[str, Any] = missing
     # manual __init__ to allow for unknown kwargs
     def __init__(
         self,
@@ -74,6 +74,8 @@ class Collection(RDF):
         **implicitly_unknown,
     ):
         self.collection = collection
+        self.unknown = unknown or {}
+        self.unknown.update(implicitly_unknown)
         super().__init__(
             attachments=attachments,
             authors=authors,
@@ -94,5 +96,3 @@ class Collection(RDF):
             version=version,
             root_path=root_path,
         )
-        self.unknown = unknown or {}
-        self.unknown.update(implicitly_unknown)

--- a/bioimageio/spec/model/v0_3/schema.py
+++ b/bioimageio/spec/model/v0_3/schema.py
@@ -375,7 +375,7 @@ class _WeightsEntryBase(_BioImageIOSchema):
         bioimageio_description="SHA256 checksum of the source file specified. " + _common_sha256_hint,
     )
     source = fields.Union(
-        [fields.URI(), fields.RelativeLocalPath()],
+        [fields.URI(), fields.Path()],
         required=True,
         bioimageio_description="URI or path to the weights file. Preferably a url.",
     )
@@ -450,7 +450,7 @@ WeightsEntry = typing.Union[
 
 class ModelParent(_BioImageIOSchema):
     uri = fields.Union(  # todo: allow URI or DOI instead (and not local path!?)
-        [fields.URI(), fields.RelativeLocalPath()],
+        [fields.URI(), fields.Path()],
         bioimageio_description="Url of another model available on bioimage.io or path to a local model in the "
         "bioimage.io specification. If it is a url, it needs to be a github url linking to the page containing the "
         "model (NOT the raw file).",
@@ -487,7 +487,7 @@ _optional*_ with an asterisk indicates the field is optional depending on the va
     documentation = fields.Union(
         [
             fields.URL(),
-            fields.RelativeLocalPath(
+            fields.Path(
                 validate=field_validators.Attribute(
                     "suffix",
                     field_validators.Equal(
@@ -638,7 +638,7 @@ is in an unsupported format version. The current format version described here i
     )
 
     test_inputs = fields.List(
-        fields.Union([fields.URI(), fields.RelativeLocalPath()]),
+        fields.Union([fields.URI(), fields.Path()]),
         required=True,
         bioimageio_description="List of URIs or local relative paths to test inputs as described in inputs for "
         "**a single test case**. "
@@ -648,19 +648,19 @@ is in an unsupported format version. The current format version described here i
         "The extension must be '.npy'.",
     )
     test_outputs = fields.List(
-        fields.Union([fields.URI(), fields.RelativeLocalPath()]),
+        fields.Union([fields.URI(), fields.Path()]),
         required=True,
         bioimageio_description="Analog to to test_inputs.",
     )
 
     sample_inputs = fields.List(
-        fields.Union([fields.URI(), fields.RelativeLocalPath()]),
+        fields.Union([fields.URI(), fields.Path()]),
         bioimageio_description="List of URIs/local relative paths to sample inputs to illustrate possible inputs for "
         "the model, for example stored as png or tif images. "
         "The model is not tested with these sample files that serve to inform a human user about an example use case.",
     )
     sample_outputs = fields.List(
-        fields.Union([fields.URI(), fields.RelativeLocalPath()]),
+        fields.Union([fields.URI(), fields.Path()]),
         bioimageio_description="List of URIs/local relative paths to sample outputs corresponding to the "
         "`sample_inputs`.",
     )

--- a/bioimageio/spec/model/v0_4/schema.py
+++ b/bioimageio/spec/model/v0_4/schema.py
@@ -283,7 +283,7 @@ class LinkedDataset(_BioImageIOSchema):
 class ModelParent(_BioImageIOSchema):
     id = fields.BioImageIO_ID(resource_type="model")
     uri = fields.Union(
-        [fields.URI(), fields.RelativeLocalPath()], bioimageio_description="URL or local relative path of a model RDF"
+        [fields.URI(), fields.Path()], bioimageio_description="URL or local relative path of a model RDF"
     )
     sha256 = fields.SHA256(bioimageio_description="Hash of the parent model RDF. Note: the hash is not validated")
 
@@ -351,7 +351,7 @@ config:
     documentation = fields.Union(
         [
             fields.URL(),
-            fields.RelativeLocalPath(
+            fields.Path(
                 validate=field_validators.Attribute(
                     "suffix",
                     field_validators.Equal(
@@ -504,21 +504,21 @@ is in an unsupported format version. The current format version described here i
     )
 
     sample_inputs = fields.List(
-        fields.Union([fields.URI(), fields.RelativeLocalPath()]),
+        fields.Union([fields.URI(), fields.Path()]),
         validate=field_validators.Length(min=1),
         bioimageio_description="List of URIs/local relative paths to sample inputs to illustrate possible inputs for "
         "the model, for example stored as png or tif images. "
         "The model is not tested with these sample files that serve to inform a human user about an example use case.",
     )
     sample_outputs = fields.List(
-        fields.Union([fields.URI(), fields.RelativeLocalPath()]),
+        fields.Union([fields.URI(), fields.Path()]),
         validate=field_validators.Length(min=1),
         bioimageio_description="List of URIs/local relative paths to sample outputs corresponding to the "
         "`sample_inputs`.",
     )
 
     test_inputs = fields.List(
-        fields.Union([fields.URI(), fields.RelativeLocalPath()]),
+        fields.Union([fields.URI(), fields.Path()]),
         validate=field_validators.Length(min=1),
         required=True,
         bioimageio_description="List of URIs or local relative paths to test inputs as described in inputs for "
@@ -529,7 +529,7 @@ is in an unsupported format version. The current format version described here i
         "The extension must be '.npy'.",
     )
     test_outputs = fields.List(
-        fields.Union([fields.URI(), fields.RelativeLocalPath()]),
+        fields.Union([fields.URI(), fields.Path()]),
         validate=field_validators.Length(min=1),
         required=True,
         bioimageio_description="Analog to test_inputs.",

--- a/bioimageio/spec/rdf/v0_2/raw_nodes.py
+++ b/bioimageio/spec/rdf/v0_2/raw_nodes.py
@@ -5,6 +5,8 @@ serialization and deserialization are defined in schema:
 RDF <--schema--> raw nodes
 """
 import dataclasses
+import pathlib
+
 import packaging.version
 import warnings
 from dataclasses import dataclass
@@ -109,6 +111,7 @@ class RDF(ResourceDescription):
         name: str,
         type: str = missing,
         version: Union[_Missing, packaging.version.Version] = missing,
+        root_path: pathlib.Path = pathlib.Path(),
         # RDF
         attachments: Union[_Missing, Dict[str, Any]] = missing,
         authors: Union[_Missing, List[Author]] = missing,
@@ -148,12 +151,11 @@ class RDF(ResourceDescription):
         self.rdf_source = rdf_source
         self.source = source
         self.tags = tags
-        super().__init__(format_version=format_version, name=name, type=type, version=version)
+        super().__init__(format_version=format_version, name=name, type=type, version=version, root_path=root_path)
 
         if unknown_kwargs:
             # make sure we didn't forget a defined field
             field_names = set(f.name for f in dataclasses.fields(self))
-            field_names.remove("root_path")  # ignore internal root_path field
             for uk in unknown_kwargs:
                 assert uk not in field_names, uk
 

--- a/bioimageio/spec/rdf/v0_2/schema.py
+++ b/bioimageio/spec/rdf/v0_2/schema.py
@@ -20,7 +20,7 @@ class _BioImageIOSchema(SharedBioImageIOSchema):
 
 class Attachments(_BioImageIOSchema, WithUnknown):
     files = fields.List(
-        fields.Union([fields.URI(), fields.RelativeLocalPath()]),
+        fields.Union([fields.URI(), fields.Path()]),
         bioimageio_description="File attachments; included when packaging the resource.",
     )
 
@@ -56,7 +56,7 @@ class Badge(_BioImageIOSchema):
     label = fields.String(required=True, bioimageio_description="e.g. 'Open in Colab'")
     icon = fields.String(bioimageio_description="e.g. 'https://colab.research.google.com/assets/colab-badge.svg'")
     url = fields.Union(
-        [fields.URL(), fields.RelativeLocalPath()],
+        [fields.URL(), fields.Path()],
         bioimageio_description="e.g. 'https://colab.research.google.com/github/HenriquesLab/ZeroCostDL4Mic/blob/master/Colab_notebooks/U-net_2D_ZeroCostDL4Mic.ipynb'",
     )
 
@@ -126,7 +126,7 @@ E.g. the citation for the model architecture and/or the training data used."""
     config = fields.YamlDict(bioimageio_descriptio=config_bioimageio_description)
 
     covers = fields.List(
-        fields.Union([fields.URL(), fields.RelativeLocalPath()]),
+        fields.Union([fields.URL(), fields.Path()]),
         bioimageio_description="A list of cover images provided by either a relative path to the model folder, or a "
         "hyperlink starting with 'http[s]'. Please use an image smaller than 500KB and an aspect ratio width to height "
         "of 2:1. The supported image formats are: 'jpg', 'png', 'gif'.",  # todo: field_validators image format
@@ -137,7 +137,7 @@ E.g. the citation for the model architecture and/or the training data used."""
     documentation = fields.Union(
         [
             fields.URL(),
-            fields.RelativeLocalPath(
+            fields.Path(
                 validate=field_validators.Attribute(
                     "suffix",
                     field_validators.Equal(
@@ -225,7 +225,7 @@ E.g. the citation for the model architecture and/or the training data used."""
         [fields.URL(), fields.DOI()], bioimageio_description="url or doi to the source of the resource definition"
     )
     source = fields.Union(
-        [fields.URI(), fields.RelativeLocalPath()],
+        [fields.URI(), fields.Path()],
         bioimageio_description="url or local relative path to the source of the resource",
     )
 

--- a/bioimageio/spec/shared/_resolve_source.py
+++ b/bioimageio/spec/shared/_resolve_source.py
@@ -20,6 +20,7 @@ from .common import (
     BIOIMAGEIO_USE_CACHE,
     BIOIMAGEIO_SITE_CONFIG_URL,
     DOI_REGEX,
+    get_spec_type_from_type,
     no_cache_tmp_list,
     RDF_NAMES,
     tqdm,
@@ -205,9 +206,7 @@ def resolve_rdf_source_and_type(
 ) -> typing.Tuple[dict, str, typing.Union[pathlib.Path, raw_nodes.URI, bytes], str]:
     data, source_name, root = resolve_rdf_source(source)
 
-    type_ = data.get("type", "rdf")
-    if type_ not in ("rdf", "model", "collection"):
-        type_ = "rdf"
+    type_ = get_spec_type_from_type(data.get("type"))
     return data, source_name, root, type_
 
 

--- a/bioimageio/spec/shared/_resolve_source.py
+++ b/bioimageio/spec/shared/_resolve_source.py
@@ -49,7 +49,7 @@ def resolve_rdf_source(
 ) -> RDF_Source:
     # reduce possible source types
     if isinstance(source, (BytesIO, StringIO)):
-        source = source.read()
+        source = source.getvalue()
     elif isinstance(source, os.PathLike):
         source = pathlib.Path(source)
     elif isinstance(source, raw_nodes.URI):
@@ -59,7 +59,8 @@ def resolve_rdf_source(
 
         source = serialize_raw_resource_description_to_dict(source)
 
-    assert isinstance(source, (dict, pathlib.Path, str, bytes)), type(source)
+    if not isinstance(source, (dict, pathlib.Path, str, bytes)):
+        raise TypeError(f"Unexpected source type {type(source)}")
 
     if isinstance(source, pathlib.Path):
         source_name = str(source)
@@ -193,7 +194,9 @@ def resolve_rdf_source(
 
         source = yaml.load(source)
 
-    assert isinstance(source, dict), source
+    if not isinstance(source, dict):
+        raise TypeError(f"Expected dict type for loaded source, but got: {type(source)}")
+
     return RDF_Source(source, source_name, root)
 
 

--- a/bioimageio/spec/shared/common.py
+++ b/bioimageio/spec/shared/common.py
@@ -138,8 +138,8 @@ def get_patched_format_version(type_: str, format_version: str):
     return version_mod.format_version
 
 
-def get_spec_type_from_type(type_: str):
-    if type_ in ("model", "collection"):
+def get_spec_type_from_type(type_: Optional[str]):
+    if type_ in ("model", "collection", "dataset"):
         return type_
     else:
         return "rdf"

--- a/bioimageio/spec/shared/fields.py
+++ b/bioimageio/spec/shared/fields.py
@@ -327,7 +327,7 @@ class ImportableSource(String):
             source_file_field = Union(
                 [
                     URL(),
-                    RelativeLocalPath(
+                    Path(
                         validate=field_validators.Attribute(
                             "suffix",
                             field_validators.Equal(

--- a/bioimageio/spec/shared/raw_nodes.py
+++ b/bioimageio/spec/shared/raw_nodes.py
@@ -116,9 +116,6 @@ class Dependencies(RawNode):
     file: Union[URI, pathlib.Path] = missing
 
     def __str__(self):
-        if isinstance(self.file, pathlib.Path):
-            assert not self.file.is_absolute(), self.file
-
         return f"{self.manager}:{self.file}"
 
 

--- a/bioimageio/spec/shared/schema.py
+++ b/bioimageio/spec/shared/schema.py
@@ -86,7 +86,7 @@ class WithUnknown(SharedBioImageIOSchema):
 class Dependencies(SharedBioImageIOSchema):
     manager = fields.String(bioimageio_description="Dependency manager For example: 'conda', 'maven', or 'pip'")
     file = fields.Union(
-        [fields.URI(), fields.RelativeLocalPath()],
+        [fields.URI(), fields.Path()],
         bioimageio_description="Dependency file. For example: 'environment.yaml', 'pom.xml', or 'requirements.txt'",
     )
 

--- a/example_specs/collections/partner_collection/datasets/dummy-dataset/README.md
+++ b/example_specs/collections/partner_collection/datasets/dummy-dataset/README.md
@@ -1,0 +1,1 @@
+# Amazing documentation

--- a/example_specs/collections/partner_collection/datasets/dummy-dataset/rdf.yaml
+++ b/example_specs/collections/partner_collection/datasets/dummy-dataset/rdf.yaml
@@ -1,0 +1,12 @@
+authors:
+- name: Fynn Beuttenmüller
+cite: []
+covers: []
+description: Dummy dataset for testing purposes only.
+documentation: README.md
+format_version: 0.2.2
+license: MIT
+name: Dummy Data
+tags: [dummy]
+type: dataset
+id: dummy-dataset

--- a/example_specs/collections/partner_collection/rdf.yaml
+++ b/example_specs/collections/partner_collection/rdf.yaml
@@ -1,0 +1,10 @@
+format_version: 0.2.2
+type: collection
+name: Partner Collection
+tags: [bioimage.io, partner-software]
+description: "Resources for BioImgage.IO curated by the partner team."
+id: partner
+collection:
+  - rdf_source: datasets/dummy-dataset/rdf.yaml
+
+

--- a/example_specs/collections/unet2d_nuclei_broad_coll/rdf.yaml
+++ b/example_specs/collections/unet2d_nuclei_broad_coll/rdf.yaml
@@ -65,9 +65,9 @@ sample_outputs: [test_output.npy]
 version: 0.1.0
 
 collection:
-  - id: with_rdf_source_url
-    rdf_source: https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/models/unet2d_nuclei_broad/rdf.yaml
-    name: UNet 2D Nuclei Broad (latest)
+#  - id: with_rdf_source_url
+#    rdf_source: https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/models/unet2d_nuclei_broad/rdf.yaml
+#    name: UNet 2D Nuclei Broad (latest)
   - id: in_place_0.4.0
     format_version: 0.4.0
     type: model
@@ -93,27 +93,27 @@ collection:
        source: weights.pt
        parent: https://zenodo.org/record/3446812/files/unet2d_weights.torch
 
-  - id: in_place_0.4.1
-    format_version: 0.4.1
-    type: model
-    weights:
-      pytorch_state_dict:
-       authors:
-         - name: "Constantin Pape;@bioimage-io"
-           affiliation: "EMBL Heidelberg"
-           orcid: "0000-0001-6562-7187"
-       sha256: e4d3885bccbe41cbf6c1d825f3cd2b707c7021ead5593156007e407a16b27cf2
-       source: https://zenodo.org/record/3446812/files/unet2d_weights.torch
-       architecture: unet2d_.py:UNet2d
-       architecture_sha256: cf42a6d86adeb4eb6e8e37b539a20e5413866b183bed88f4e2e26ad1639761ed
-       kwargs: {input_channels: 1, output_channels: 1}
-       dependencies: conda:environment.yaml
-      onnx:
-       sha256: 5bf14c4e65e8601ab551db99409ba7981ff0e501719bc2b0ee625ca9a9375b32
-       source: weights.onnx
-       opset_version: 12
-       parent: https://zenodo.org/record/3446812/files/unet2d_weights.torch
-      torchscript:
-       sha256: 62fa1c39923bee7d58a192277e0dd58f2da9ee810662addadd0f44a3784d9210
-       source: weights.pt
-       parent: https://zenodo.org/record/3446812/files/unet2d_weights.torch
+#  - id: in_place_0.4.1
+#    format_version: 0.4.1
+#    type: model
+#    weights:
+#      pytorch_state_dict:
+#       authors:
+#         - name: "Constantin Pape;@bioimage-io"
+#           affiliation: "EMBL Heidelberg"
+#           orcid: "0000-0001-6562-7187"
+#       sha256: e4d3885bccbe41cbf6c1d825f3cd2b707c7021ead5593156007e407a16b27cf2
+#       source: https://zenodo.org/record/3446812/files/unet2d_weights.torch
+#       architecture: unet2d_.py:UNet2d
+#       architecture_sha256: cf42a6d86adeb4eb6e8e37b539a20e5413866b183bed88f4e2e26ad1639761ed
+#       kwargs: {input_channels: 1, output_channels: 1}
+#       dependencies: conda:environment.yaml
+#      onnx:
+#       sha256: 5bf14c4e65e8601ab551db99409ba7981ff0e501719bc2b0ee625ca9a9375b32
+#       source: weights.onnx
+#       opset_version: 12
+#       parent: https://zenodo.org/record/3446812/files/unet2d_weights.torch
+#      torchscript:
+#       sha256: 62fa1c39923bee7d58a192277e0dd58f2da9ee810662addadd0f44a3784d9210
+#       source: weights.pt
+#       parent: https://zenodo.org/record/3446812/files/unet2d_weights.torch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def unet2d_nuclei_broad_collection():
 
 
 @pytest.fixture
-def partner_collection_path():
+def partner_collection():
     return pathlib.Path(__file__).parent / "../example_specs/collections/partner_collection/rdf.yaml"
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,7 @@ def get_unet2d_nuclei_broad(unet2d_nuclei_broad_base_path, request) -> dict:
         v = f"_{request.param}"
 
     f_name = f"rdf{v}.yaml"
-    path = unet2d_nuclei_broad_base_path / f_name
-    return yaml.load(path)
+    return unet2d_nuclei_broad_base_path / f_name
 
 
 @pytest.fixture(params=["v0_3_0", "v0_3_1", "v0_3_2", "v0_3_3", "v0_3_6", "v0_4_0", "v0_4_5"])
@@ -42,18 +41,18 @@ def unet2d_nuclei_broad_any_minor(unet2d_nuclei_broad_base_path, request):
 
 
 @pytest.fixture
-def unet2d_nuclei_broad_latest_path(unet2d_nuclei_broad_base_path):
-    return unet2d_nuclei_broad_base_path / "rdf.yaml"
-
-
-@pytest.fixture
 def invalid_rdf_v0_4_0_duplicate_tensor_names(unet2d_nuclei_broad_base_path):
-    return yaml.load(unet2d_nuclei_broad_base_path / "invalid_rdf_v0_4_0_duplicate_tensor_names.yaml")
+    return unet2d_nuclei_broad_base_path / "invalid_rdf_v0_4_0_duplicate_tensor_names.yaml"
 
 
 @pytest.fixture
 def unet2d_nuclei_broad_collection():
-    return yaml.load(pathlib.Path(__file__).parent / "../example_specs/collections/unet2d_nuclei_broad_coll/rdf.yaml")
+    return pathlib.Path(__file__).parent / "../example_specs/collections/unet2d_nuclei_broad_coll/rdf.yaml"
+
+
+@pytest.fixture
+def partner_collection_path():
+    return pathlib.Path(__file__).parent / "../example_specs/collections/partner_collection/rdf.yaml"
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,18 +1,23 @@
 import os
 import subprocess
 import zipfile
+from typing import Sequence
 
 from bioimageio.spec.io_ import load_raw_resource_description, save_raw_resource_description
 from bioimageio.spec.shared import yaml
 
 
-def test_cli_validate_model(unet2d_nuclei_broad_latest_path):
-    ret = subprocess.run(["bioimageio", "validate", str(unet2d_nuclei_broad_latest_path)])
+def run_subprocess(commands: Sequence[str], **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(commands, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding="utf-8", **kwargs)
+
+
+def test_cli_validate_model(unet2d_nuclei_broad_latest):
+    ret = run_subprocess(["bioimageio", "validate", str(unet2d_nuclei_broad_latest)])
     assert ret.returncode == 0
 
 
 def test_cli_validate_model_url():
-    ret = subprocess.run(
+    ret = run_subprocess(
         [
             "bioimageio",
             "validate",
@@ -25,7 +30,7 @@ def test_cli_validate_model_url():
 def test_cli_validate_model_url_wo_cache():
     env = os.environ.copy()
     env["BIOIMAGEIO_USE_CACHE"] = "false"
-    ret = subprocess.run(
+    ret = run_subprocess(
         [
             "bioimageio",
             "validate",
@@ -37,28 +42,28 @@ def test_cli_validate_model_url_wo_cache():
 
 
 def test_cli_validate_model_doi():
-    ret = subprocess.run(["bioimageio", "validate", "10.5281/zenodo.5744489"])
+    ret = run_subprocess(["bioimageio", "validate", "10.5281/zenodo.5744489"])
     assert ret.returncode == 0
 
 
-def test_cli_validate_model_package(unet2d_nuclei_broad_latest_path, tmpdir):
+def test_cli_validate_model_package(unet2d_nuclei_broad_latest, tmpdir):
     zf_path = tmpdir / "package.zip"
     with zipfile.ZipFile(zf_path, "w") as zf:
-        zf.write(unet2d_nuclei_broad_latest_path, "rdf.yaml")
+        zf.write(unet2d_nuclei_broad_latest, "rdf.yaml")
 
-    ret = subprocess.run(["bioimageio", "validate", str(zf_path)])
+    ret = run_subprocess(["bioimageio", "validate", str(zf_path)])
     assert ret.returncode == 0
 
 
-def test_cli_validate_model_package_wo_cache(unet2d_nuclei_broad_latest_path, tmpdir):
+def test_cli_validate_model_package_wo_cache(unet2d_nuclei_broad_latest, tmpdir):
     env = os.environ.copy()
     env["BIOIMAGEIO_USE_CACHE"] = "false"
 
     zf_path = tmpdir / "package.zip"
     with zipfile.ZipFile(zf_path, "w") as zf:
-        zf.write(unet2d_nuclei_broad_latest_path, "rdf.yaml")
+        zf.write(unet2d_nuclei_broad_latest, "rdf.yaml")
 
-    ret = subprocess.run(["bioimageio", "validate", str(zf_path)], env=env)
+    ret = run_subprocess(["bioimageio", "validate", str(zf_path)], env=env)
     assert ret.returncode == 0
 
 
@@ -67,7 +72,7 @@ def test_cli_update_format(unet2d_nuclei_broad_before_latest, tmp_path):
     save_raw_resource_description(load_raw_resource_description(unet2d_nuclei_broad_before_latest), in_path)
     assert in_path.exists()
     path = tmp_path / "rdf_new.yaml"
-    ret = subprocess.run(["bioimageio", "update-format", str(in_path), str(path)])
+    ret = run_subprocess(["bioimageio", "update-format", str(in_path), str(path)])
     assert ret.returncode == 0
     assert path.exists()
 
@@ -78,7 +83,7 @@ def test_update_rdf(unet2d_nuclei_broad_base_path, tmp_path):
     update_path = tmp_path / "update.yaml"
     yaml.dump(dict(name="updated", outputs=[{"name": "updated", "halo": ["KEEP", "DROP", 0, 9, 9]}]), update_path)
     out_path = tmp_path / "output.yaml"
-    ret = subprocess.run(["bioimageio", "update-rdf", str(in_path), str(update_path), str(out_path)])
+    ret = run_subprocess(["bioimageio", "update-rdf", str(in_path), str(update_path), str(out_path)])
     assert ret.returncode == 0
     actual = yaml.load(out_path)
     assert actual["name"] == "updated"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,11 @@ import subprocess
 import zipfile
 from typing import Sequence
 
-from bioimageio.spec.io_ import load_raw_resource_description, save_raw_resource_description
+from bioimageio.spec.io_ import (
+    load_raw_resource_description,
+    save_raw_resource_description,
+    serialize_raw_resource_description,
+)
 from bioimageio.spec.shared import yaml
 
 
@@ -48,8 +52,13 @@ def test_cli_validate_model_doi():
 
 def test_cli_validate_model_package(unet2d_nuclei_broad_latest, tmpdir):
     zf_path = tmpdir / "package.zip"
+
+    # load from path and serialize with absolute paths
+    raw_rd = load_raw_resource_description(unet2d_nuclei_broad_latest)
+    rdf_str = serialize_raw_resource_description(raw_rd, convert_absolute_paths=False)
+
     with zipfile.ZipFile(zf_path, "w") as zf:
-        zf.write(unet2d_nuclei_broad_latest, "rdf.yaml")
+        zf.writestr("rdf.yaml", rdf_str)
 
     ret = run_subprocess(["bioimageio", "validate", str(zf_path)])
     assert ret.returncode == 0
@@ -59,9 +68,13 @@ def test_cli_validate_model_package_wo_cache(unet2d_nuclei_broad_latest, tmpdir)
     env = os.environ.copy()
     env["BIOIMAGEIO_USE_CACHE"] = "false"
 
+    # load from path and serialize with absolute paths
+    raw_rd = load_raw_resource_description(unet2d_nuclei_broad_latest)
+    rdf_str = serialize_raw_resource_description(raw_rd, convert_absolute_paths=False)
+
     zf_path = tmpdir / "package.zip"
     with zipfile.ZipFile(zf_path, "w") as zf:
-        zf.write(unet2d_nuclei_broad_latest, "rdf.yaml")
+        zf.writestr("rdf.yaml", rdf_str)
 
     ret = run_subprocess(["bioimageio", "validate", str(zf_path)], env=env)
     assert ret.returncode == 0

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,9 +1,11 @@
 import zipfile
-from copy import copy
 from io import BytesIO, StringIO
 
-from bioimageio.core import serialize_raw_resource_description
-from bioimageio.spec import load_raw_resource_description, serialize_raw_resource_description_to_dict
+from bioimageio.spec import (
+    load_raw_resource_description,
+    serialize_raw_resource_description,
+    serialize_raw_resource_description_to_dict,
+)
 from bioimageio.spec.model import format_version, raw_nodes
 from bioimageio.spec.shared import yaml
 
@@ -226,10 +228,11 @@ def test_update_rdf_using_dicts(unet2d_nuclei_broad_latest):
 
     # load from path and serialize with absolute paths
     raw_rd = load_raw_resource_description(unet2d_nuclei_broad_latest)
-    source = serialize_raw_resource_description_to_dict(raw_rd)
+    source = serialize_raw_resource_description_to_dict(raw_rd, convert_absolute_paths=False)
 
     update = dict(name="updated", outputs=[{"name": "updated", "halo": ["KEEP", "DROP", 0, 9, 9]}])
     actual = update_rdf(source, update)
+    assert isinstance(actual, dict)
     assert actual["name"] == "updated"
     assert actual["outputs"][0]["name"] == "updated"
     assert actual["outputs"][0]["halo"] == [0, 0, 9, 9]
@@ -240,7 +243,7 @@ def test_update_rdf_using_dicts_in_place(unet2d_nuclei_broad_latest):
 
     # load from path and serialize with absolute paths
     raw_rd = load_raw_resource_description(unet2d_nuclei_broad_latest)
-    source = serialize_raw_resource_description_to_dict(raw_rd)
+    source = serialize_raw_resource_description_to_dict(raw_rd, convert_absolute_paths=False)
 
     update = dict(name="updated", outputs=[{"name": "updated", "halo": ["KEEP", "DROP", 0, 9, 9]}])
     update_rdf(source, update, output=source)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,7 +2,8 @@ import zipfile
 from copy import copy
 from io import BytesIO, StringIO
 
-from bioimageio.spec import load_raw_resource_description
+from bioimageio.core import serialize_raw_resource_description
+from bioimageio.spec import load_raw_resource_description, serialize_raw_resource_description_to_dict
 from bioimageio.spec.model import format_version, raw_nodes
 from bioimageio.spec.shared import yaml
 
@@ -87,48 +88,67 @@ def test_validate_model_as_bioimageio_resource_id_zenodo():
     assert summary["status"] == "passed", summary["error"]
 
 
-def test_validate_model_as_bytes_io(unet2d_nuclei_broad_latest_path):
+def test_validate_model_as_bytes_io(unet2d_nuclei_broad_latest):
     from bioimageio.spec.commands import validate
 
-    data = BytesIO(unet2d_nuclei_broad_latest_path.read_bytes())
+    # load from path and serialize with absolute paths
+    raw_rd = load_raw_resource_description(unet2d_nuclei_broad_latest)
+    data_str = serialize_raw_resource_description(raw_rd, convert_absolute_paths=False)
+
+    data = BytesIO(data_str.encode("utf-8"))
     data.seek(0)
     assert not validate(data, update_format=True, update_format_inner=False)["error"]
     data.seek(0)
     assert not validate(data, update_format=False, update_format_inner=False)["error"]
 
 
-def test_validate_model_as_string_io(unet2d_nuclei_broad_latest_path):
+def test_validate_model_as_string_io(unet2d_nuclei_broad_latest):
     from bioimageio.spec.commands import validate
 
-    data = StringIO(unet2d_nuclei_broad_latest_path.read_text())
+    # load from path and serialize with absolute paths
+    raw_rd = load_raw_resource_description(unet2d_nuclei_broad_latest)
+    data_str = serialize_raw_resource_description(raw_rd, convert_absolute_paths=False)
+
+    data = StringIO(data_str)
     data.seek(0)
     assert not validate(data, update_format=True, update_format_inner=False)["error"]
     data.seek(0)
     assert not validate(data, update_format=False, update_format_inner=False)["error"]
 
 
-def test_validate_model_as_bytes(unet2d_nuclei_broad_latest_path):
+def test_validate_model_as_bytes(unet2d_nuclei_broad_latest):
     from bioimageio.spec.commands import validate
 
-    data = unet2d_nuclei_broad_latest_path.read_bytes()
+    # load from path and serialize with absolute paths
+    raw_rd = load_raw_resource_description(unet2d_nuclei_broad_latest)
+    data_str = serialize_raw_resource_description(raw_rd, convert_absolute_paths=False)
+
+    data = data_str.encode("utf-8")
     assert not validate(data, update_format=True, update_format_inner=False)["error"]
     assert not validate(data, update_format=False, update_format_inner=False)["error"]
 
 
-def test_validate_model_as_string(unet2d_nuclei_broad_latest_path):
+def test_validate_model_as_string(unet2d_nuclei_broad_latest):
     from bioimageio.spec.commands import validate
 
-    data = unet2d_nuclei_broad_latest_path.read_text()
+    # load from path and serialize with absolute paths
+    raw_rd = load_raw_resource_description(unet2d_nuclei_broad_latest)
+    data = serialize_raw_resource_description(raw_rd, convert_absolute_paths=False)
+
     assert not validate(data, update_format=True, update_format_inner=False)["error"]
     assert not validate(data, update_format=False, update_format_inner=False)["error"]
 
 
-def test_validate_model_package_as_bytes(unet2d_nuclei_broad_latest_path):
+def test_validate_model_package_as_bytes(unet2d_nuclei_broad_latest):
     from bioimageio.spec.commands import validate
+
+    # load from path and serialize with absolute paths
+    raw_rd = load_raw_resource_description(unet2d_nuclei_broad_latest)
+    rdf_str = serialize_raw_resource_description(raw_rd, convert_absolute_paths=False)
 
     data = BytesIO()
     with zipfile.ZipFile(data, "w") as zf:
-        zf.write(unet2d_nuclei_broad_latest_path, "rdf.yaml")
+        zf.writestr("rdf.yaml", rdf_str)
 
     data.seek(0)
     assert not validate(data, update_format=True, update_format_inner=False)["error"]
@@ -136,12 +156,16 @@ def test_validate_model_package_as_bytes(unet2d_nuclei_broad_latest_path):
     assert not validate(data, update_format=False, update_format_inner=False)["error"]
 
 
-def test_validate_model_package_on_disk(unet2d_nuclei_broad_latest_path, tmpdir):
+def test_validate_model_package_on_disk(unet2d_nuclei_broad_latest, tmpdir):
     from bioimageio.spec.commands import validate
+
+    # load from path and serialize with absolute paths
+    raw_rd = load_raw_resource_description(unet2d_nuclei_broad_latest)
+    rdf_str = serialize_raw_resource_description(raw_rd, convert_absolute_paths=False)
 
     zf_path = tmpdir / "package.zip"
     with zipfile.ZipFile(zf_path, "w") as zf:
-        zf.write(unet2d_nuclei_broad_latest_path, "rdf.yaml")
+        zf.writestr("rdf.yaml", rdf_str)
 
     assert not validate(zf_path, update_format=True, update_format_inner=False)["error"]
     assert not validate(zf_path, update_format=False, update_format_inner=False)["error"]
@@ -150,7 +174,10 @@ def test_validate_model_package_on_disk(unet2d_nuclei_broad_latest_path, tmpdir)
 def test_validate_invalid_model(unet2d_nuclei_broad_latest):
     from bioimageio.spec.commands import validate
 
-    data = copy(unet2d_nuclei_broad_latest)
+    # load from path and serialize with absolute paths
+    raw_rd = load_raw_resource_description(unet2d_nuclei_broad_latest)
+    data = serialize_raw_resource_description_to_dict(raw_rd)
+
     del data["test_inputs"]  # invalidate data
     assert validate(data, update_format=True, update_format_inner=False)["error"]
     assert validate(data, update_format=False, update_format_inner=False)["error"]
@@ -159,7 +186,8 @@ def test_validate_invalid_model(unet2d_nuclei_broad_latest):
 def test_validate_generates_warnings(unet2d_nuclei_broad_latest):
     from bioimageio.spec.commands import validate
 
-    data = copy(unet2d_nuclei_broad_latest)
+    raw_rd = load_raw_resource_description(unet2d_nuclei_broad_latest)
+    data = serialize_raw_resource_description_to_dict(raw_rd)
     data["license"] = "BSD-2-Clause-FreeBSD"
     data["run_mode"] = {"name": "fancy"}
     summary = validate(data, update_format=True, update_format_inner=False)
@@ -178,10 +206,10 @@ def test_update_format(unet2d_nuclei_broad_before_latest, tmp_path):
     assert model.format_version == format_version
 
 
-def test_update_rdf_using_paths(unet2d_nuclei_broad_base_path, tmp_path):
+def test_update_rdf_using_paths(unet2d_nuclei_broad_latest, tmp_path):
     from bioimageio.spec.commands import update_rdf
 
-    in_path = unet2d_nuclei_broad_base_path / "rdf.yaml"
+    in_path = unet2d_nuclei_broad_latest
     assert in_path.exists()
     update_path = tmp_path / "update.yaml"
     yaml.dump(dict(name="updated", outputs=[{"name": "updated", "halo": ["KEEP", "DROP", 0, 9, 9]}]), update_path)
@@ -196,7 +224,10 @@ def test_update_rdf_using_paths(unet2d_nuclei_broad_base_path, tmp_path):
 def test_update_rdf_using_dicts(unet2d_nuclei_broad_latest):
     from bioimageio.spec.commands import update_rdf
 
-    source = unet2d_nuclei_broad_latest
+    # load from path and serialize with absolute paths
+    raw_rd = load_raw_resource_description(unet2d_nuclei_broad_latest)
+    source = serialize_raw_resource_description_to_dict(raw_rd)
+
     update = dict(name="updated", outputs=[{"name": "updated", "halo": ["KEEP", "DROP", 0, 9, 9]}])
     actual = update_rdf(source, update)
     assert actual["name"] == "updated"
@@ -207,7 +238,10 @@ def test_update_rdf_using_dicts(unet2d_nuclei_broad_latest):
 def test_update_rdf_using_dicts_in_place(unet2d_nuclei_broad_latest):
     from bioimageio.spec.commands import update_rdf
 
-    source = unet2d_nuclei_broad_latest
+    # load from path and serialize with absolute paths
+    raw_rd = load_raw_resource_description(unet2d_nuclei_broad_latest)
+    source = serialize_raw_resource_description_to_dict(raw_rd)
+
     update = dict(name="updated", outputs=[{"name": "updated", "halo": ["KEEP", "DROP", 0, 9, 9]}])
     update_rdf(source, update, output=source)
     actual = source

--- a/tests/test_commands_with_collection.py
+++ b/tests/test_commands_with_collection.py
@@ -1,4 +1,4 @@
-from copy import copy
+from bioimageio.spec import load_raw_resource_description, serialize_raw_resource_description_to_dict
 
 
 def test_validate(unet2d_nuclei_broad_collection):
@@ -11,7 +11,9 @@ def test_validate(unet2d_nuclei_broad_collection):
 def test_validate_invalid(unet2d_nuclei_broad_collection):
     from bioimageio.spec.commands import validate
 
-    data = copy(unet2d_nuclei_broad_collection)
+    raw_rd = load_raw_resource_description(unet2d_nuclei_broad_collection)
+    data = serialize_raw_resource_description_to_dict(raw_rd, convert_absolute_paths=False)
+
     data["collection"][0]["name"] = 1  # invalidate data
     assert validate(data, update_format=True, update_format_inner=False)["error"]
     assert validate(data, update_format=False, update_format_inner=False)["error"]

--- a/tests/test_dump_spec.py
+++ b/tests/test_dump_spec.py
@@ -1,17 +1,23 @@
+from bioimageio.spec.shared import yaml
+
+
 def test_spec_round_trip(unet2d_nuclei_broad_any_minor):
     from bioimageio.spec import load_raw_resource_description, serialize_raw_resource_description_to_dict
 
-    data = unet2d_nuclei_broad_any_minor
+    expected = yaml.load(unet2d_nuclei_broad_any_minor)
     # monkeypatch: yaml.load already converts timestamp to datetime.datetime, while we serialize it to ISO 8601
-    if "timestamp" in data:
-        data["timestamp"] = data["timestamp"].isoformat()
+    if "timestamp" in expected:
+        expected["timestamp"] = expected["timestamp"].isoformat()
 
+    # round-trip
     raw_model = load_raw_resource_description(unet2d_nuclei_broad_any_minor)
+    serialized = serialize_raw_resource_description_to_dict(raw_model, convert_absolute_paths=True)
 
-    serialized = serialize_raw_resource_description_to_dict(raw_model)
     assert isinstance(serialized, dict)
-    assert serialized == data
+    assert expected == serialized
 
+    # as we converted absolute paths back to relative, we need to set the root path
+    serialized["root_path"] = unet2d_nuclei_broad_any_minor.parent
     raw_model_from_serialized = load_raw_resource_description(serialized)
     assert raw_model_from_serialized == raw_model
 
@@ -19,7 +25,9 @@ def test_spec_round_trip(unet2d_nuclei_broad_any_minor):
 def test_spec_round_trip_w_attachments(unet2d_nuclei_broad_latest):
     from bioimageio.spec import load_raw_resource_description, serialize_raw_resource_description_to_dict
 
-    data = unet2d_nuclei_broad_latest
+    data = yaml.load(unet2d_nuclei_broad_latest)
+    data["root_path"] = unet2d_nuclei_broad_latest.parent
+
     # monkeypatch: yaml.load already converts timestamp to datetime.datetime, while we serialize it to ISO 8601
     if "timestamp" in data:
         data["timestamp"] = data["timestamp"].isoformat()
@@ -28,8 +36,9 @@ def test_spec_round_trip_w_attachments(unet2d_nuclei_broad_latest):
 
     raw_model = load_raw_resource_description(data)
 
-    serialized = serialize_raw_resource_description_to_dict(raw_model)
+    serialized = serialize_raw_resource_description_to_dict(raw_model, convert_absolute_paths=True)
     assert isinstance(serialized, dict)
+    serialized["root_path"] = unet2d_nuclei_broad_latest.parent
     assert serialized == data
 
     raw_model_from_serialized = load_raw_resource_description(serialized)

--- a/tests/test_format_version_conversion.py
+++ b/tests/test_format_version_conversion.py
@@ -1,13 +1,14 @@
 from dataclasses import asdict
 
 from bioimageio.spec.model import schema
+from bioimageio.spec.shared import yaml
 
 
 def test_model_format_version_conversion(unet2d_nuclei_broad_before_latest, unet2d_nuclei_broad_latest):
     from bioimageio.spec.model.converters import maybe_convert
 
-    old_model_data = unet2d_nuclei_broad_before_latest
-    model_data = unet2d_nuclei_broad_latest
+    old_model_data = yaml.load(unet2d_nuclei_broad_before_latest)
+    model_data = yaml.load(unet2d_nuclei_broad_latest)
 
     expected = asdict(schema.Model().load(model_data))
     converted_data = maybe_convert(old_model_data)

--- a/tests/test_raw_load_resource_description.py
+++ b/tests/test_raw_load_resource_description.py
@@ -1,5 +1,6 @@
 from bioimageio.spec.model import raw_nodes
 from bioimageio.spec import collection
+from bioimageio.spec.shared import yaml
 
 
 def test_load_raw_model(unet2d_nuclei_broad_any):
@@ -65,24 +66,28 @@ def test_load_raw_model_unet2d_keras_tf(unet2d_keras_tf):
 def test_load_raw_model_to_format(unet2d_nuclei_broad_before_latest):
     from bioimageio.spec import load_raw_resource_description
 
+    data = yaml.load(unet2d_nuclei_broad_before_latest)
+    data["root_path"] = unet2d_nuclei_broad_before_latest.parent
     format_targets = [(0, 3), (0, 4)]
-    format_version = tuple(map(int, unet2d_nuclei_broad_before_latest["format_version"].split(".")[:2]))
+    format_version = tuple(map(int, data["format_version"].split(".")[:2]))
 
     for target in format_targets:
         if format_version <= target:
             to_format = ".".join(map(str, target))
-            raw_model = load_raw_resource_description(unet2d_nuclei_broad_before_latest, update_to_format=to_format)
+            raw_model = load_raw_resource_description(data, update_to_format=to_format)
             assert raw_model.format_version[: raw_model.format_version.rfind(".")] == to_format
 
 
 def test_collection_with_relative_path_in_rdf_source_of_an_entry(partner_collection):
     from bioimageio.spec import load_raw_resource_description
     from bioimageio.spec.collection.utils import resolve_collection_entries
+    from bioimageio.spec.dataset.v0_2.raw_nodes import Dataset
 
     coll = load_raw_resource_description(partner_collection)
     assert isinstance(coll, collection.raw_nodes.Collection)
     resolved_entries = resolve_collection_entries(coll)
-    for entry_data, entry_error in resolved_entries:
-        assert entry_data["documentation"].endswith(
+    for entry_rdf, entry_error in resolved_entries:
+        assert isinstance(entry_rdf, Dataset)
+        assert entry_rdf.documentation.as_posix().endswith(
             "example_specs/collections/partner_collection/datasets/dummy-dataset/README.md"
         )

--- a/tests/test_raw_load_resource_description.py
+++ b/tests/test_raw_load_resource_description.py
@@ -1,4 +1,5 @@
 from bioimageio.spec.model import raw_nodes
+from bioimageio.spec import collection
 
 
 def test_load_raw_model(unet2d_nuclei_broad_any):
@@ -72,3 +73,16 @@ def test_load_raw_model_to_format(unet2d_nuclei_broad_before_latest):
             to_format = ".".join(map(str, target))
             raw_model = load_raw_resource_description(unet2d_nuclei_broad_before_latest, update_to_format=to_format)
             assert raw_model.format_version[: raw_model.format_version.rfind(".")] == to_format
+
+
+def test_collection_with_relative_path_in_rdf_source_of_an_entry(partner_collection):
+    from bioimageio.spec import load_raw_resource_description
+    from bioimageio.spec.collection.utils import resolve_collection_entries
+
+    coll = load_raw_resource_description(partner_collection)
+    assert isinstance(coll, collection.raw_nodes.Collection)
+    resolved_entries = resolve_collection_entries(coll)
+    for entry_data, entry_error in resolved_entries:
+        assert entry_data["documentation"].endswith(
+            "example_specs/collections/partner_collection/datasets/dummy-dataset/README.md"
+        )

--- a/tests/test_schema_model.py
+++ b/tests/test_schema_model.py
@@ -3,20 +3,28 @@ from datetime import datetime
 import pytest
 from marshmallow import ValidationError
 
+from bioimageio.spec.shared import yaml
+
 
 def test_model_rdf_is_valid_general_rdf(unet2d_nuclei_broad_latest):
     from bioimageio.spec.rdf.schema import RDF
 
-    RDF().load(unet2d_nuclei_broad_latest)
+    data = yaml.load(unet2d_nuclei_broad_latest)
+    data["root_path"] = unet2d_nuclei_broad_latest.parent
+
+    RDF().load(data)
 
 
 def test_model_does_not_accept_unknown_fields(unet2d_nuclei_broad_latest):
     from bioimageio.spec.model.schema import Model
 
-    unet2d_nuclei_broad_latest["unknown_additional_field"] = "shouldn't be here"
+    data = yaml.load(unet2d_nuclei_broad_latest)
+    data["root_path"] = unet2d_nuclei_broad_latest.parent
+
+    data["unknown_additional_field"] = "shouldn't be here"
 
     with pytest.raises(ValidationError):
-        Model().load(unet2d_nuclei_broad_latest)
+        Model().load(data)
 
 
 @pytest.fixture
@@ -91,13 +99,14 @@ def test_model_0_4_raises_on_duplicate_tensor_names(invalid_rdf_v0_4_0_duplicate
     from bioimageio.spec.model.schema import Model
     from bioimageio.spec.model.v0_3.schema import Model as Model_v03
 
+    data = yaml.load(invalid_rdf_v0_4_0_duplicate_tensor_names)
+
     model_schema = Model()
     with pytest.raises(ValidationError):
-        model_schema.load(invalid_rdf_v0_4_0_duplicate_tensor_names)
+        model_schema.load(data)
 
     # as 0.3 the model should still be valid with some small changes
     model_schema = Model_v03()
-    data = dict(invalid_rdf_v0_4_0_duplicate_tensor_names)
     data["format_version"] = "0.3.3"
     data["language"] = "python"
     data["framework"] = "pytorch"

--- a/tests/test_validation_errors.py
+++ b/tests/test_validation_errors.py
@@ -1,10 +1,12 @@
 """check for meaningful validation errors for various invalid input"""
+from bioimageio.spec.shared import yaml
 
 
 def test_list_instead_of_nested_schema(unet2d_nuclei_broad_latest):
     from bioimageio.spec.commands import validate
 
-    data = unet2d_nuclei_broad_latest
+    data = yaml.load(unet2d_nuclei_broad_latest)
+
     # set wrong run_mode (list)
     data["run_mode"] = [{"name": "something"}]
 


### PR DESCRIPTION
this PR makes sure we don't forget a resource location when manipulating a loaded resource or loading a nested resource as is the case in a collection RDF with entries that specifie `rdf_source`. 

When serializing the user has the option to keep absolute paths or to convert them to relative ones (should be used when saving to a yaml file).