### PR TITLE
Support loading from nickname

### DIFF
--- a/bioimageio/spec/shared/_resolve_source.py
+++ b/bioimageio/spec/shared/_resolve_source.py
@@ -416,7 +416,7 @@ T = typing.TypeVar("T")
 def _resolve_json_from_url(
     url: str,
     expected_type: typing.Union[typing.Type[dict], typing.Type[T]] = dict,
-    warning_msg: str = "Failed to fetch {url}: {error}",
+    warning_msg: typing.Optional[str] = "Failed to fetch {url}: {error}",
     encoding: typing.Optional[str] = None,
 ) -> typing.Tuple[typing.Optional[T], typing.Optional[str]]:
     try:
@@ -437,9 +437,11 @@ def _resolve_json_from_url(
 
 
 BIOIMAGEIO_SITE_CONFIG, BIOIMAGEIO_SITE_CONFIG_ERROR = _resolve_json_from_url(
-    BIOIMAGEIO_SITE_CONFIG_URL, encoding="utf-8"
+    BIOIMAGEIO_SITE_CONFIG_URL, encoding="utf-8", warning_msg=None
 )
-BIOIMAGEIO_COLLECTION, BIOIMAGEIO_COLLECTION_ERROR = _resolve_json_from_url(BIOIMAGEIO_COLLECTION_URL, encoding="utf-8")
+BIOIMAGEIO_COLLECTION, BIOIMAGEIO_COLLECTION_ERROR = _resolve_json_from_url(
+    BIOIMAGEIO_COLLECTION_URL, encoding="utf-8", warning_msg=None
+)
 if BIOIMAGEIO_COLLECTION is None:
     BIOIMAGEIO_COLLECTION_ENTRIES: typing.Optional[typing.Dict[str, typing.Tuple[str, str]]] = None
 else:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -6,3 +6,14 @@ def test_get_resource_package_content(unet2d_nuclei_broad_latest, unet2d_nuclei_
     local_keys = set(from_local_content)
     remote_keys = set(from_remote_content)
     assert local_keys == remote_keys
+
+
+def test_load_animal_nickname():
+    from bioimageio.spec import load_raw_resource_description
+    from bioimageio.spec.model.v0_4.raw_nodes import Model as Model04
+
+    nickname = "impartial-shrimp"
+    model = load_raw_resource_description(nickname)
+    assert isinstance(model, Model04)
+    assert model.format_version.split(".")[:2] == (0, 4)
+    assert model.config["bioimageio"]["nickname"] == nickname

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -15,5 +15,5 @@ def test_load_animal_nickname():
     nickname = "impartial-shrimp"
     model = load_raw_resource_description(nickname)
     assert isinstance(model, Model04)
-    assert model.format_version.split(".")[:2] == (0, 4)
+    assert ".".join(model.format_version.split(".")[:2]) == "0.4"
     assert model.config["bioimageio"]["nickname"] == nickname


### PR DESCRIPTION
Besides enabling loading models via nickanme this PR disables the warning messages if the cache hits https://raw.githubusercontent.com/bioimage-io/bioimage.io/main/site.config.json or  https://bioimage-io.github.io/collection-bioimage-io/collection.json which are downloaded during import