### PR TITLE
allow root_path to be URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ As a dependency it is included in [bioimageio.core](https://github.com/bioimage-
 | BIOIMAGEIO_CACHE_WARNINGS_LIMIT | "3" | Maximum number of warnings generated for simple cache hits. |
 
 ## Changelog
+#### bioimageio.spec 0.5.4.post14
+- keep `ResourceDescrption.root_path` as URI for remote resources. This fixes the collection RDF as the collection entries are resolved after the collection RDF has been loaded.
+
 #### bioimageio.spec 0.5.4.post13
 - new bioimageio.spec.partner module adding validate-partner-collection command if optional 'lxml' dependency is available
 

--- a/bioimageio/spec/VERSION
+++ b/bioimageio/spec/VERSION
@@ -1,3 +1,3 @@
 {
-    "version": "0.4.5post13"
+    "version": "0.4.5post14"
 }

--- a/tests/test_node_transformer.py
+++ b/tests/test_node_transformer.py
@@ -59,7 +59,7 @@ class TestNodeVisitor:
 
 
 def test_resolve_remote_relative_path():
-    from bioimageio.spec.shared.node_transformer import PathToRemoteUriTransformer
+    from bioimageio.spec.shared.node_transformer import RelativePathTransformer
 
     remote_rdf = raw_nodes.URI(
         "https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/models/"
@@ -67,7 +67,7 @@ def test_resolve_remote_relative_path():
     )
     remote_relative_path = Path("unet2d.py")
 
-    uri = PathToRemoteUriTransformer(remote_source=remote_rdf).transform(remote_relative_path)
+    uri = RelativePathTransformer(root=remote_rdf.parent).transform(remote_relative_path)
 
     assert (
         str(uri) == "https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/models/"

--- a/tests/test_raw_nodes.py
+++ b/tests/test_raw_nodes.py
@@ -61,6 +61,31 @@ def test_uri_is_url():
     assert str(uri) == url
 
 
+def test_uri_truediv():
+    from bioimageio.spec.shared.raw_nodes import URI
+
+    url = "https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/models/unet2d_nuclei_broad?download=1"
+    rel_path = "test_input.npy"
+    expected = URI(
+        f"https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/models/unet2d_nuclei_broad/{rel_path}?download=1"
+    )
+    uri = URI(url)
+    assert expected == uri / rel_path
+    assert expected == uri / rel_path  # ensure we did not change uri in-place
+
+
+def test_uri_parent():
+    from bioimageio.spec.shared.raw_nodes import URI
+
+    url = "https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/models/unet2d_nuclei_broad/test_input.npy?download=1"
+    expected = URI(
+        "https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/models/unet2d_nuclei_broad?download=1"
+    )
+    uri = URI(url)
+    assert expected == uri.parent
+    assert expected == uri.parent  # ensure we did not change uri in-place
+
+
 def test_general_rdf_accepts_unknown_fields():
     from bioimageio.spec.rdf.raw_nodes import RDF
 


### PR DESCRIPTION
to resolve collection entries after the collection RDF has been loaded, we need to 'remember' the root.
Resolving everything in one go would be another approach, but would require the collection entry update logic to be fixed, which we want to avoid to support enriching the collection entries with fields from imjoy plugins. 