### PR TITLE
Disable documentation for bioengine apps

### DIFF
--- a/bioimageio/spec/partner/imjoy_plugin_parser.py
+++ b/bioimageio/spec/partner/imjoy_plugin_parser.py
@@ -132,10 +132,10 @@ def convert_config_to_rdf(plugin_config, source_url=None) -> dict:
     rdf["tags"] = tags
 
     docs = plugin_config.get("docs")
-    if isinstance(docs, dict):
-        rdf["documentation"] = docs.get("content")
-    elif isinstance(docs, str):
-        rdf["documentation"] = docs
+#     if isinstance(docs, dict):
+#         rdf["documentation"] = docs.get("content")
+#     elif isinstance(docs, str):
+#         rdf["documentation"] = docs
     rdf["covers"] = plugin_config.get("cover")
     # make sure we have a list
     if not rdf["covers"]:


### PR DESCRIPTION
BioEngine apps with documentation are failing because we don't allow string in the doucmentation field: https://github.com/imjoy-team/bioimage-io-models/runs/6349058588?check_suite_focus=true#step:4:22

I need to disable this conversion now.

@FynnBe do you see a way that we can generate a local file from the string and link it to the application item?