### PR TITLE
fix enrich_partial_rdf_with_imjoy_plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ As a dependency it is included in [bioimageio.core](https://github.com/bioimage-
 | BIOIMAGEIO_CACHE_WARNINGS_LIMIT | "3" | Maximum number of warnings generated for simple cache hits. |
 
 ## Changelog
+#### bioimageio.spec 0.4.6post1
+- fix enrich_partial_rdf_with_imjoy_plugin (see https://github.com/bioimage-io/spec-bioimage-io/pull/452)
+
 #### bioimageio.spec 0.4.5post16
 - fix rdf_update of entries in `resolve_collection_entries()`
 

--- a/bioimageio/spec/VERSION
+++ b/bioimageio/spec/VERSION
@@ -1,3 +1,3 @@
 {
-    "version": "0.4.6"
+    "version": "0.4.6post1"
 }

--- a/bioimageio/spec/partner/utils.py
+++ b/bioimageio/spec/partner/utils.py
@@ -24,11 +24,15 @@ def enrich_partial_rdf_with_imjoy_plugin(partial_rdf: Dict[str, Any], root: Unio
             # rdf_source is an actual rdf
             if not isinstance(rdf_source, dict):
                 try:
-                    rdf_source = root / rdf_source
                     rdf_source, rdf_source_name, rdf_source_root = resolve_rdf_source(rdf_source)
                 except Exception as e:
-                    warnings.warn(f"Failed to resolve `rdf_source`: {e}")
-                    rdf_source = {}
+                    try:
+                        rdf_source, rdf_source_name, rdf_source_root = resolve_rdf_source(root / rdf_source)
+                    except Exception as ee:
+                        rdf_source = {}
+                        warnings.warn(f"Failed to resolve `rdf_source`: 1. {e}\n2. {ee}")
+                    else:
+                        rdf_source["root_path"] = rdf_source_root  # enables remote source content to be resolved
                 else:
                     rdf_source["root_path"] = rdf_source_root  # enables remote source content to be resolved
 


### PR DESCRIPTION
when resolving rdf_source we cannot turn it into a path `root / rdf_source` but need to try to resolve it before as it may be a URL.