### PR TITLE
update/fixed pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: stable
+    rev: 22.6.0
     hooks:
     - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v0.961
     hooks:
       - id: mypy
-        args: [--install-types, --non-interactive]
+        additional_dependencies: [types-requests]
   - repo: local
     hooks:
     - id: generate rdf docs


### PR DESCRIPTION
"random" update/fix of pre-commit config - as I could get it to work with the current settings.

Summary:

* [use of `--install-types` is discouraged](https://github.com/pre-commit/mirrors-mypy#using-mypy-with-pre-commit)
  added type dependencies for requests manually instead.
* updated black to a proper revision (was `stable` before, which generated a warning)
* update mypy, because, why not while I'm at it.