### PR TITLE
load future format version as latest with warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ As a dependency it is included in [bioimageio.core](https://github.com/bioimage-
 | BIOIMAGEIO_CACHE_WARNINGS_LIMIT | "3" | Maximum number of warnings generated for simple cache hits. |
 
 ## Changelog
+#### bioimageio.spec 0.4.7post1
+- add simple forward compatibility by treating future format versions as latest known (for the respective resource type)
+
 #### bioimageio.spec 0.4.6post3
 - Make CLI output more readable
 - find redirected URLs when checking for URL availability

--- a/bioimageio/spec/VERSION
+++ b/bioimageio/spec/VERSION
@@ -1,3 +1,3 @@
 {
-    "version": "0.4.7"
+    "version": "0.4.7post1"
 }

--- a/bioimageio/spec/io_.py
+++ b/bioimageio/spec/io_.py
@@ -159,6 +159,7 @@ def load_raw_resource_description(
 
     class_name = get_class_name_from_type(type_)
 
+    # determine submodule's format version
     original_data_version = data.get("format_version")
     if original_data_version is None:
         odv: Optional[Version] = None
@@ -187,6 +188,7 @@ def load_raw_resource_description(
             raise e  # raise original error; no second attempt with 'LATEST' format version
 
         try:
+            # load latest spec submodule
             sub_spec = _get_spec_submodule(type_, data_version=LATEST)
         except ValueError:
             raise e  # raise original error with desired data_version
@@ -195,7 +197,7 @@ def load_raw_resource_description(
             # original format version is not a future version.
             # => we should not fall back to latest format version.
             # => 'format_version' may be invalid or the issue lies with 'type_'...
-            raise
+            raise e
 
     if odv and Version(sub_spec.format_version) < odv:
         warnings.warn(

--- a/bioimageio/spec/io_.py
+++ b/bioimageio/spec/io_.py
@@ -190,7 +190,9 @@ def load_raw_resource_description(
                 f"Loading future {type_} format version {original_data_version} as (latest known) "
                 f"{sub_spec.format_version}."
             )
-            data["format_version"] = sub_spec.format_version
+            data["format_version"] = sub_spec.format_version  # set format_version to latest available
+
+            # save original format version under config:bioimageio:original_format_version for reference
             if "config" not in data:
                 data["config"] = {}
 

--- a/bioimageio/spec/io_.py
+++ b/bioimageio/spec/io_.py
@@ -180,28 +180,28 @@ def load_raw_resource_description(
         except ValueError:
             raise e  # raise original error with desired data_version
 
-        try:
-            odv = Version(original_data_version)
-        except Exception as e:
-            raise ValueError(f"Invalid format version {original_data_version}.") from e
+    try:
+        odv = Version(original_data_version)
+    except Exception as e:
+        raise ValueError(f"Invalid format version {original_data_version}.") from e
 
-        if Version(sub_spec.format_version) < odv:
-            warnings.warn(
-                f"Loading future {type_} format version {original_data_version} as (latest known) "
-                f"{sub_spec.format_version}."
-            )
-            data["format_version"] = sub_spec.format_version  # set format_version to latest available
+    if Version(sub_spec.format_version) < odv:
+        warnings.warn(
+            f"Loading future {type_} format version {original_data_version} as (latest known) "
+            f"{sub_spec.format_version}."
+        )
+        data["format_version"] = sub_spec.format_version  # set format_version to latest available
 
-            # save original format version under config:bioimageio:original_format_version for reference
-            if "config" not in data:
-                data["config"] = {}
+        # save original format version under config:bioimageio:original_format_version for reference
+        if "config" not in data:
+            data["config"] = {}
 
-            if "bioimageio" not in data["config"]:
-                data["config"]["bioimageio"] = {}
+        if "bioimageio" not in data["config"]:
+            data["config"]["bioimageio"] = {}
 
-            data["config"]["bioimageio"]["original_format_version"] = original_data_version
-        else:
-            raise  # data_version may be invalid or the issue lies elsewhere...
+        data["config"]["bioimageio"]["original_format_version"] = original_data_version
+    else:
+        raise  # data_version may be invalid or the issue lies elsewhere...
 
     schema: SharedBioImageIOSchema = getattr(sub_spec.schema, class_name)()
 

--- a/bioimageio/spec/shared/_resolve_source.py
+++ b/bioimageio/spec/shared/_resolve_source.py
@@ -272,7 +272,7 @@ def _resolve_source_path(
     output: typing.Optional[os.PathLike] = None,
     pbar=None,
 ) -> pathlib.Path:
-    if not source.is_absolute():
+    if not os.path.isabs(source):
         if isinstance(root_path, os.PathLike):
             root_path = pathlib.Path(root_path).resolve()
         source = root_path / source

--- a/tests/test_format_version_conversion.py
+++ b/tests/test_format_version_conversion.py
@@ -1,4 +1,8 @@
 from dataclasses import asdict
+from typing import Tuple
+
+import pytest
+from packaging.version import Version
 
 from bioimageio.spec.model import schema
 from bioimageio.spec.shared import yaml
@@ -39,3 +43,27 @@ def test_model_format_version_conversion(unet2d_nuclei_broad_before_latest, unet
     for key, item in actual.items():
         assert key in expected
         assert item == expected[key]
+
+
+# todo: break forward compatibility on major version difference?
+@pytest.mark.parametrize("v_diff", [(0, 0, 1), (0, 1, 0), (1, 0, 0), (0, 1, 1)])
+def test_forward_compatible(v_diff: Tuple[int, int, int], unet2d_nuclei_broad_latest):
+    from bioimageio.spec import load_raw_resource_description
+    from bioimageio.spec.model import format_version
+
+    fv_key = "format_version"
+
+    model_data = yaml.load(unet2d_nuclei_broad_latest)
+
+    v_latest: Version = Version(format_version)
+    v_future: str = ".".join(
+        [str(latest + diff) for latest, diff in zip([v_latest.major, v_latest.minor + 1, v_latest.micro], v_diff)]
+    )
+
+    future_model_data = dict(model_data)
+    future_model_data[fv_key] = v_future
+
+    rd = load_raw_resource_description(future_model_data)
+    assert rd.format_version == format_version
+    assert hasattr(rd, "config")
+    assert rd.config["bioimageio"]["original_format_version"] == v_future

--- a/tests/test_format_version_conversion.py
+++ b/tests/test_format_version_conversion.py
@@ -57,7 +57,7 @@ def test_forward_compatible(v_diff: Tuple[int, int, int], unet2d_nuclei_broad_la
 
     v_latest: Version = Version(format_version)
     v_future: str = ".".join(
-        [str(latest + diff) for latest, diff in zip([v_latest.major, v_latest.minor + 1, v_latest.micro], v_diff)]
+        [str(latest + diff) for latest, diff in zip([v_latest.major, v_latest.minor, v_latest.micro], v_diff)]
     )
 
     future_model_data = dict(model_data)


### PR DESCRIPTION
any format version higher than the respective type's latest known is loaded as latest instead.

fixes #468