### PR TITLE
add axes and eps(ilon) kwarg to `scale_mean_variance`

### DIFF
--- a/bioimageio/spec/model/v0_3/schema.py
+++ b/bioimageio/spec/model/v0_3/schema.py
@@ -251,6 +251,18 @@ class Postprocessing(Processing):
             validate=field_validators.Predicate("isidentifier"),
             bioimageio_description="Name of tensor to match.",
         )
+        axes = fields.Axes(
+            valid_axes="czyx",
+            bioimageio_description="The subset of axes to scale jointly. For example xy to normalize the two image "
+            "axes for 2d data jointly. The batch axis (b) is not valid here. "
+            "Default: scale all non-batch axes jointly.",
+        )
+        eps = fields.Float(
+            missing=1e-6,
+            bioimageio_description="Epsilon for numeric stability: "
+            "`out  = (tensor - mean) / (std + eps) * (ref_std + eps) + ref_mean. "
+            "Default value: 10^-6.",
+        )
 
 
 class InputTensor(_TensorBase):


### PR DESCRIPTION
while implementing scale_mean_variance in bioimageio.core I noted that `axes` and `eps` could easily be added and makes this postprocessing more analogous to `scale_range`, `scale_linear` and `zero_mean_unit_variance`