### PR TITLE
Fix processing kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ As a dependency it is included in [bioimageio.core](https://github.com/bioimage-
 | BIOIMAGEIO_CACHE_WARNINGS_LIMIT | "3" | Maximum number of warnings generated for simple cache hits. |
 
 ## Changelog
+#### bioimageio.spec tbd
+- make pre-/postprocessing kwargs `mode` and `axes` always optional for model RDF 0.3 and 0.4
+
 #### bioimageio.spec 0.4.8post1
 - add `axes` and `eps` to `scale_mean_var`
 

--- a/bioimageio/spec/model/v0_3/schema.py
+++ b/bioimageio/spec/model/v0_3/schema.py
@@ -94,17 +94,22 @@ class Processing(_BioImageIOSchema):
     class scale_linear(SharedProcessingSchema):
         bioimageio_description = "Fixed linear scaling."
         axes = fields.Axes(
-            required=True,
             valid_axes="czyx",
             bioimageio_description="The subset of axes to scale jointly. "
             "For example xy to scale the two image axes for 2d data jointly. "
             "The batch axis (b) is not valid here.",
         )
         gain = fields.Array(
-            fields.Float(), missing=fields.Float(missing=1.0), bioimageio_description="multiplicative factor"
+            fields.Float(),
+            bioimageio_maybe_required=True,
+            missing=fields.Float(missing=1.0),
+            bioimageio_description="multiplicative factor",
         )  # todo: check if gain match input axes
         offset = fields.Array(
-            fields.Float(), missing=fields.Float(missing=0.0), bioimageio_description="additive term"
+            fields.Float(),
+            bioimageio_maybe_required=True,
+            missing=fields.Float(missing=0.0),
+            bioimageio_description="additive term",
         )  # todo: check if offset match input axes
 
         @validates_schema
@@ -142,7 +147,6 @@ class Processing(_BioImageIOSchema):
         bioimageio_description = "Subtract mean and divide by variance."
         mode = fields.ProcMode(required=True)
         axes = fields.Axes(
-            required=True,
             valid_axes="czyx",
             bioimageio_description="The subset of axes to normalize jointly. For example xy to normalize the two image "
             "axes for 2d data jointly. The batch axis (b) is not valid here.",
@@ -191,7 +195,6 @@ class Preprocessing(Processing):
         bioimageio_description = "Scale with percentiles."
         mode = fields.ProcMode(required=True, valid_modes=("per_dataset", "per_sample"))
         axes = fields.Axes(
-            required=True,
             valid_axes="czyx",
             bioimageio_description="The subset of axes to normalize jointly. For example xy to normalize the two image "
             "axes for 2d data jointly. The batch axis (b) is not valid here.",

--- a/bioimageio/spec/model/v0_3/schema.py
+++ b/bioimageio/spec/model/v0_3/schema.py
@@ -71,7 +71,6 @@ class _TensorBase(_BioImageIOSchema):
         axes = data["axes"]
         processing_list = data.get(self.processing_name, [])
         for processing in processing_list:
-            name = processing.name
             kwargs = processing.kwargs or {}
             kwarg_axes = kwargs.get("axes", "")
             if any(a not in axes for a in kwarg_axes):
@@ -145,7 +144,7 @@ class Processing(_BioImageIOSchema):
 
     class zero_mean_unit_variance(SharedProcessingSchema):
         bioimageio_description = "Subtract mean and divide by variance."
-        mode = fields.ProcMode(required=True)
+        mode = fields.ProcMode()
         axes = fields.Axes(
             valid_axes="czyx",
             bioimageio_description="The subset of axes to normalize jointly. For example xy to normalize the two image "
@@ -168,12 +167,12 @@ class Processing(_BioImageIOSchema):
 
         @validates_schema
         def mean_and_std_match_mode(self, data, **kwargs):
-            if data["mode"] == "fixed" and ("mean" not in data or "std" not in data):
+            if data.get("mode", "fixed") == "fixed" and ("mean" not in data or "std" not in data):
                 raise ValidationError(
                     "`kwargs` for 'zero_mean_unit_variance' preprocessing with `mode` 'fixed' require additional "
                     "`kwargs`: `mean` and `std`."
                 )
-            elif data["mode"] != "fixed" and ("mean" in data or "std" in data):
+            elif data.get("mode", "fixed") != "fixed" and ("mean" in data or "std" in data):
                 raise ValidationError(
                     "`kwargs`: `mean` and `std` for 'zero_mean_unit_variance' preprocessing are only valid for `mode` 'fixed'."
                 )
@@ -193,7 +192,7 @@ class Preprocessing(Processing):
 
     class scale_range(SharedProcessingSchema):
         bioimageio_description = "Scale with percentiles."
-        mode = fields.ProcMode(required=True, valid_modes=("per_dataset", "per_sample"))
+        mode = fields.ProcMode(valid_modes=("per_dataset", "per_sample"))
         axes = fields.Axes(
             valid_axes="czyx",
             bioimageio_description="The subset of axes to normalize jointly. For example xy to normalize the two image "
@@ -248,7 +247,7 @@ class Postprocessing(Processing):
 
     class scale_mean_variance(SharedProcessingSchema):
         bioimageio_description = "Scale the tensor s.t. its mean and variance match a reference tensor."
-        mode = fields.ProcMode(required=True, valid_modes=("per_dataset", "per_sample"))
+        mode = fields.ProcMode(valid_modes=("per_dataset", "per_sample"))
         reference_tensor = fields.String(
             required=True,
             validate=field_validators.Predicate("isidentifier"),

--- a/bioimageio/spec/shared/schema.py
+++ b/bioimageio/spec/shared/schema.py
@@ -49,8 +49,11 @@ class SharedBioImageIOSchema(Schema):
 class SharedProcessingSchema(Schema):
     """Used to generate Pre- and Postprocessing documentation.
 
-    Define Pre-/Postprocessing schemas in the Preprocessing/Postprocessing schema that inherite from this class
-    and they will be rendered in the documentation."""
+    Define Pre-/Postprocessing operator schemas in the Preprocessing/Postprocessing schema that inherit from this class,
+    and they will be rendered in the documentation (scripts/generate_processing_docs.py).
+
+    example: bioimageio.spec.model.v0_3.schema.Processing.binarize
+    """
 
     bioimageio_description: ClassVar[str]
 


### PR DESCRIPTION
Found some inconsistencies in the pre- and postprocessing kwargs..
we required `axes` and `mode` kwargs to be specified despite having sensible default values for them. 

Also `scale_linear`'s `gain` and `offset` are conditionally mandatory (at least one needs to be set). The `bioimageio_maybe_required` flag ensures the documentation marks that with an asterisk *.
