### PR TITLE
Proposal for missing category tags warning

### DIFF
--- a/bioimageio/spec/rdf/v0_2/schema.py
+++ b/bioimageio/spec/rdf/v0_2/schema.py
@@ -257,7 +257,7 @@ E.g. the citation for the model architecture and/or the training data used."""
             else:
                 error = None
                 if missing_categories:
-                    self.warn("tags", f"Missing tags for categories: {missing_categories}")
+                    self.warn("tags", f"Missing tags corresponding to bioimage.io categories: {missing_categories}")
 
         if error is not None:
             self.warn("tags", f"could not check tag categories ({error})")


### PR DESCRIPTION
Hi!

I have been confused in the past about what the "Missing tags for categories: [{..}]" meant, since it was not clear from the warning that the tags and categories were the same than those used in "Tags and Filters" in the website. 

Here is a proposal to make it clearer to consumers what is meant by replacing:
"Missing tags for categories"
by
"Missing tags corresponding to bioimage.io categories"

I am not convinced this is the most eloquent way to phrase it, but I wanted to open the conversation. :)