### PR TITLE
add bioimageio_description to email field

### DIFF
--- a/bioimageio/spec/rdf/v0_2/schema.py
+++ b/bioimageio/spec/rdf/v0_2/schema.py
@@ -31,7 +31,7 @@ class Attachments(_BioImageIOSchema, WithUnknown):
 class _Person(_BioImageIOSchema):
     name = fields.Name(bioimageio_description="Full name.")
     affiliation = fields.String(bioimageio_description="Affiliation.")
-    email = fields.Email()
+    email = fields.Email(bioimageio_description="E-Mail")
     github_user = fields.String(bioimageio_description="GitHub user name.")  # todo: add validation?
     orcid = fields.String(
         validate=[


### PR DESCRIPTION
currently `email` does not show up in our documentation. This PR changes that