### PR TITLE
add close method to tqdm dummy

### DIFF
--- a/bioimageio/spec/shared/common.py
+++ b/bioimageio/spec/shared/common.py
@@ -51,6 +51,9 @@ except ImportError:
         def update(self, *args, **kwargs):
             pass
 
+        def close(self):
+            pass
+
 
 class CacheWarning(RuntimeWarning):
     pass


### PR DESCRIPTION
currently if a download fails we get an additional error from the missing `tqdm.close()` method. This PR fixes that.