### PR TITLE
Enforce version field values to be string

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,24 @@ As a dependency it is included in [bioimageio.core](https://github.com/bioimage-
 
 
 ### RDF Format Versions
-#### bioimageio.spec 0.4.9
+#### RDF 0.2.4
+- Breaking changes that are fully auto-convertible
+  - `version` needs to be specified as string (not int or float) to avoid truncating zeros (in case of floats like 2.10)
+    auto-conversion casts previous version values blindly to string
+
+
+#### model RDF 0.4.10
+- Breaking changes that are fully auto-convertible
+  - `version`, `pytorch_version`, and `tensorflow_version` need to be specified as string (not int or float) to avoid truncating zeros (in case of floats like 2.10)
+    auto-conversion casts previous version values blindly to string
+
+#### model RDF 0.3.7
+- Breaking changes that are fully auto-convertible
+  - `version` and `tensorflow_version` need to be specified as string (not int or float) to avoid truncating zeros (in case of floats like 2.10)
+    auto-conversion casts previous version values blindly to string
+
+
+#### model RDF 0.4.9
 - Non-breaking changes
   - make pre-/postprocessing kwargs `mode` and `axes` always optional for model RDF 0.3 and 0.4
 

--- a/bioimageio/spec/model/v0_3/converters.py
+++ b/bioimageio/spec/model/v0_3/converters.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Union
 
 from marshmallow import Schema
 
+from bioimageio.spec.rdf.v0_2.converters import cast_version_value_to_string
 from . import raw_nodes, schema
 
 AUTO_CONVERTED_DOCUMENTATION_FILE_NAME = "auto_converted_documentation.md"
@@ -90,6 +91,12 @@ def convert_model_v0_3_2_to_v0_3_3(data: Dict[str, Any]) -> Dict[str, Any]:
     return data
 
 
+def cast_tf_version_to_string(data: Dict[str, Any]) -> None:
+    for wf in data.get("weights", []):
+        if "tensorflow_version" in wf:
+            wf["tensorflow_version"] = str(wf["tensorflow_version"])
+
+
 def maybe_convert(data: Dict[str, Any]) -> Dict[str, Any]:
     """auto converts model 'data' to newest format"""
 
@@ -107,6 +114,11 @@ def maybe_convert(data: Dict[str, Any]) -> Dict[str, Any]:
 
     if data["format_version"] in ("0.3.3", "0.3.4", "0.3.5"):
         data["format_version"] = "0.3.6"
+
+    if data["format_version"] == "0.3.6":
+        cast_tf_version_to_string(data)
+        cast_version_value_to_string(data)
+        data["format_version"] = "0.3.7"
 
     # remove 'future' from config if no other than the used future entries exist
     config = data.get("config", {})

--- a/bioimageio/spec/model/v0_3/raw_nodes.py
+++ b/bioimageio/spec/model/v0_3/raw_nodes.py
@@ -27,7 +27,7 @@ except ImportError:
 Maintainer = Maintainer
 
 FormatVersion = Literal[
-    "0.3.0", "0.3.1", "0.3.2", "0.3.3", "0.3.4", "0.3.5", "0.3.6"
+    "0.3.0", "0.3.1", "0.3.2", "0.3.3", "0.3.4", "0.3.5", "0.3.6", "0.3.7"
 ]  # newest format needs to be last (used in __init__.py)
 Framework = Literal["pytorch", "tensorflow"]
 Language = Literal["python", "java"]

--- a/bioimageio/spec/model/v0_4/converters.py
+++ b/bioimageio/spec/model/v0_4/converters.py
@@ -5,6 +5,8 @@ from marshmallow import missing
 
 from bioimageio.spec.rdf.v0_2.converters import remove_slash_from_names
 
+from bioimageio.spec.rdf.v0_2.converters import cast_version_value_to_string
+
 
 def convert_model_from_v0_3_to_0_4_0(data: Dict[str, Any]) -> Dict[str, Any]:
     from bioimageio.spec.model import v0_3
@@ -75,6 +77,13 @@ def convert_model_from_v0_4_6_to_0_4_7(data: Dict[str, Any]) -> Dict[str, Any]:
     return data
 
 
+def cast_framework_versions_to_string(data: Dict[str, Any]) -> None:
+    for wf in data.get("weights", []):
+        for v in ["pytorch_version", "tensorflow_version"]:
+            if v in wf:
+                wf[v] = str(wf[v])
+
+
 def maybe_convert(data: Dict[str, Any]) -> Dict[str, Any]:
     """auto converts model 'data' to newest format"""
     major, minor, patch = map(int, data.get("format_version", "0.3.0").split("."))
@@ -101,6 +110,11 @@ def maybe_convert(data: Dict[str, Any]) -> Dict[str, Any]:
 
     if data["format_version"] == "0.4.8":
         data["format_version"] = "0.4.9"
+
+    if data["format_version"] == "0.4.9":
+        cast_version_value_to_string(data)
+        cast_framework_versions_to_string(data)
+        data["format_version"] = "0.4.10"
 
     # remove 'future' from config if no other than the used future entries exist
     config = data.get("config", {})

--- a/bioimageio/spec/model/v0_4/raw_nodes.py
+++ b/bioimageio/spec/model/v0_4/raw_nodes.py
@@ -50,7 +50,7 @@ Preprocessing = Preprocessing
 PreprocessingName = PreprocessingName
 
 FormatVersion = Literal[
-    "0.4.0", "0.4.1", "0.4.2", "0.4.3", "0.4.4", "0.4.5", "0.4.6", "0.4.7", "0.4.8", "0.4.9"
+    "0.4.0", "0.4.1", "0.4.2", "0.4.3", "0.4.4", "0.4.5", "0.4.6", "0.4.7", "0.4.8", "0.4.9", "0.4.10"
 ]  # newest format needs to be last (used in __init__.py)
 WeightsFormat = Literal[
     "pytorch_state_dict", "torchscript", "keras_hdf5", "tensorflow_js", "tensorflow_saved_model_bundle", "onnx"

--- a/bioimageio/spec/rdf/v0_2/converters.py
+++ b/bioimageio/spec/rdf/v0_2/converters.py
@@ -15,6 +15,11 @@ def remove_slash_from_names(data: Dict[str, Any]) -> None:
             p["name"] = p["name"].replace("/", "").replace("\\", "")
 
 
+def cast_version_value_to_string(data: Dict[str, Any]) -> None:
+    if "version" in data:
+        data["version"] = str(data["version"])
+
+
 def maybe_convert(data: Dict[str, Any]) -> Dict[str, Any]:
     data = copy.deepcopy(data)
 
@@ -29,5 +34,9 @@ def maybe_convert(data: Dict[str, Any]) -> Dict[str, Any]:
     if data.get("format_version") == "0.2.2":
         remove_slash_from_names(data)
         data["format_version"] = "0.2.3"
+
+    if data.get("format_version") == "0.2.3":
+        cast_version_value_to_string(data)
+        data["format_version"] = "0.2.4"
 
     return data

--- a/bioimageio/spec/rdf/v0_2/raw_nodes.py
+++ b/bioimageio/spec/rdf/v0_2/raw_nodes.py
@@ -24,7 +24,7 @@ except ImportError:
     from typing_extensions import Literal, get_args  # type: ignore
 
 FormatVersion = Literal[
-    "0.2.0", "0.2.1", "0.2.2", "0.2.3"
+    "0.2.0", "0.2.1", "0.2.2", "0.2.3", "0.2.4"
 ]  # newest format needs to be last (used to determine latest format version)
 
 

--- a/bioimageio/spec/shared/fields.py
+++ b/bioimageio/spec/shared/fields.py
@@ -555,7 +555,13 @@ class Version(String):
         data: typing.Optional[typing.Mapping[str, typing.Any]],
         **kwargs,
     ):
-        return packaging.version.Version(str(value))
+        if not isinstance(value, str):
+            raise ValidationError(
+                f"version {value} not given as string. "
+                f"Interpreting version as float might truncate zeros. "
+                f"Please use an explicit 'string'."
+            )
+        return packaging.version.Version(value)
 
 
 class URI(String):


### PR DESCRIPTION
YAML load `2.10` as float 2.1. When specifying a version, e.g. `tensorflow_version` we need to ensure the value is written as string `'2.10'` to ensure we interpret the version correctly.

E.g. this lead to confusion in https://github.com/bioimage-io/collection-bioimage-io/pull/531

The changes from this PR will not trigger a release (yet) as the VERSION file is left untouched. We can add more changes before realease of 0.4.10