### PR TITLE
Disable url suffix checks

### DIFF
--- a/bioimageio/spec/VERSION
+++ b/bioimageio/spec/VERSION
@@ -1,3 +1,3 @@
 {
-    "version": "0.4.9post2"
+    "version": "0.4.9post3"
 }

--- a/bioimageio/spec/model/v0_3/schema.py
+++ b/bioimageio/spec/model/v0_3/schema.py
@@ -3,7 +3,15 @@ import warnings
 from copy import deepcopy
 from types import ModuleType
 
-from marshmallow import RAISE, ValidationError, missing as missing_, post_load, pre_dump, pre_load, validates_schema
+from marshmallow import (
+    RAISE,
+    ValidationError,
+    post_load,
+    pre_dump,
+    pre_load,
+    validates_schema,
+)
+from marshmallow import missing as missing_
 
 from bioimageio.spec.rdf import v0_2 as rdf
 from bioimageio.spec.shared import field_validators, fields
@@ -15,6 +23,7 @@ from bioimageio.spec.shared.schema import (
     SharedProcessingSchema,
 )
 from bioimageio.spec.shared.utils import get_ref_url
+
 from . import raw_nodes
 
 Author = rdf.schema.Author

--- a/bioimageio/spec/model/v0_3/schema.py
+++ b/bioimageio/spec/model/v0_3/schema.py
@@ -512,14 +512,7 @@ _optional*_ with an asterisk indicates the field is optional depending on the va
     documentation = fields.Union(
         [
             fields.URL(),
-            fields.Path(
-                validate=field_validators.Attribute(
-                    "suffix",
-                    field_validators.Equal(
-                        ".md", error="{!r} is invalid; expected markdown file with '.md' extension."
-                    ),
-                )
-            ),
+            fields.Path(),
         ],
         required=True,
         bioimageio_description="Relative path to file with additional documentation in markdown. This means: 1) only "

--- a/bioimageio/spec/model/v0_4/schema.py
+++ b/bioimageio/spec/model/v0_4/schema.py
@@ -3,23 +3,49 @@ from copy import deepcopy
 from types import ModuleType
 
 import numpy
-from marshmallow import RAISE, ValidationError, missing, pre_load, validates, validates_schema
+from marshmallow import (
+    RAISE,
+    ValidationError,
+    missing,
+    pre_load,
+    validates,
+    validates_schema,
+)
 
 from bioimageio.spec.dataset.v0_2.schema import Dataset as _Dataset
 from bioimageio.spec.model.v0_3.schema import (
     KerasHdf5WeightsEntry as KerasHdf5WeightsEntry03,
+)
+from bioimageio.spec.model.v0_3.schema import (
     OnnxWeightsEntry as OnnxWeightsEntry03,
+)
+from bioimageio.spec.model.v0_3.schema import (
     Postprocessing as Postprocessing03,
+)
+from bioimageio.spec.model.v0_3.schema import (
     Preprocessing as Preprocessing03,
+)
+from bioimageio.spec.model.v0_3.schema import (
     TensorflowJsWeightsEntry as TensorflowJsWeightsEntry03,
+)
+from bioimageio.spec.model.v0_3.schema import (
     TensorflowSavedModelBundleWeightsEntry as TensorflowSavedModelBundleWeightsEntry03,
-    _WeightsEntryBase as _WeightsEntryBase03,
+)
+from bioimageio.spec.model.v0_3.schema import (
     _common_sha256_hint,
+)
+from bioimageio.spec.model.v0_3.schema import (
+    _WeightsEntryBase as _WeightsEntryBase03,
 )
 from bioimageio.spec.rdf import v0_2 as rdf
 from bioimageio.spec.shared import LICENSES, field_validators, fields
 from bioimageio.spec.shared.common import get_args, get_args_flat
-from bioimageio.spec.shared.schema import ImplicitOutputShape, ParametrizedInputShape, SharedBioImageIOSchema
+from bioimageio.spec.shared.schema import (
+    ImplicitOutputShape,
+    ParametrizedInputShape,
+    SharedBioImageIOSchema,
+)
+
 from . import raw_nodes
 
 

--- a/bioimageio/spec/model/v0_4/schema.py
+++ b/bioimageio/spec/model/v0_4/schema.py
@@ -382,14 +382,7 @@ config:
     documentation = fields.Union(
         [
             fields.URL(),
-            fields.Path(
-                validate=field_validators.Attribute(
-                    "suffix",
-                    field_validators.Equal(
-                        ".md", error="{!r} is invalid; expected markdown file with '.md' extension."
-                    ),
-                )
-            ),
+            fields.Path(),
         ],
         required=True,
         bioimageio_description="Relative path or URL to file with additional documentation in markdown. "

--- a/bioimageio/spec/shared/fields.py
+++ b/bioimageio/spec/shared/fields.py
@@ -1,13 +1,14 @@
 """fields to be used in the versioned schemas (may return shared raw nodes on `deserialize`"""
 import datetime
-import packaging.version
 import logging
 import pathlib
 import typing
 
 import marshmallow_union
 import numpy
-from marshmallow import Schema, ValidationError, fields as marshmallow_fields, missing
+import packaging.version
+from marshmallow import Schema, ValidationError, missing
+from marshmallow import fields as marshmallow_fields
 
 from . import field_validators, raw_nodes
 from .utils._docs import resolve_bioimageio_descrcription
@@ -361,14 +362,7 @@ class ImportableSource(String):
             source_file_field = Union(
                 [
                     URL(),
-                    Path(
-                        validate=field_validators.Attribute(
-                            "suffix",
-                            field_validators.Equal(
-                                ".py", error="{!r} is invalid; expected python source file with '.py' extension."
-                            ),
-                        )
-                    ),
+                    Path(),
                 ]
             )
             return raw_nodes.ImportableSourceFile(


### PR DESCRIPTION
Due to the recent Zenodo API changes zenodo file urls now terminate with "/content". 
Our current caching mechanism saves them with the filename "content" which leads to issues when validating a files suffix.

Instead of fixing caching I decided to quickly remove all suffix validation as we are close to releasing the major 0.6 version soon (that moves caching entirely to bioimageio.core).  