### PR TITLE
Streamlining axis size

### DIFF
--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -223,7 +223,7 @@ class SizeReference(Node):
     2. A channel axis may only reference another channel axis. Their scales are implicitly set to 1.
     """
 
-    reference: TensorAxisId
+    target: TensorAxisId
     scale: float = 1.0
     offset: int = 0
 

--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -293,7 +293,7 @@ class ChannelAxis(AxisBase):
     type: Literal["channel"] = "channel"
     id: AxisId = AxisId("channel")
     channel_names: Union[List[Identifier], Identifier, GenericChannelName] = "channel{i}"
-    size: Union[Annotated[int, Gt(0)], SizeReference] = "#channel_names"  # type: ignore
+    size: Union[FixedSize, SizeReference] = "#channel_names"  # type: ignore
 
     @model_validator(mode="before")
     @classmethod
@@ -318,14 +318,16 @@ class ChannelAxis(AxisBase):
 
 class IndexTimeSpaceAxisBase(AxisBase):
     size: Annotated[
-        Union[Annotated[int, Gt(0)], ParameterizedSize, SizeReference],
+        AxisSize,
         Field(
             examples=[
-                10,
+                FixedSize(extent=10),
                 "other_axis",
                 ParameterizedSize(min=32, step=16).model_dump(),
-                SizeReference(reference="other_tensor.axis").model_dump(),
-                SizeReference(reference="other_axis", offset=8).model_dump(),
+                SizeReference(
+                    reference=TensorAxisId(tensor_id="other_tensor", axis_id="other_axis"),
+                    offset=8,
+                ).model_dump(),
             ]
         ),
     ]

--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -333,7 +333,7 @@ class ChannelAxis(AxisBase):
 
 class IndexTimeSpaceAxisBase(AxisBase):
     size: Annotated[
-        Union[Annotated[int, Gt(0)], ParameterizedSize, SizeReference, AxisId, TensorAxisId],
+        Union[Annotated[int, Gt(0)], ParameterizedSize, SizeReference],
         Field(
             examples=[
                 10,

--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -154,6 +154,9 @@ class TensorAxisId(Node):
     tensor_id: TensorId
     axis_id: AxisId
 
+    def __str__(self) -> str:
+        return f"{self.tensor_id}.{self.axis_id}"
+
 NonBatchAxisId = NewType("NonBatchAxisId", Annotated[_AxisId, Predicate(lambda x: x != "batch")])
 
 PostprocessingId = Literal[

--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -230,7 +230,7 @@ class SizeReference(Node):
     ) -> "FixedSize | ParameterizedSize | None":
         visited = visited or set()
         if self.reference.tensor_id in visited:
-            return None
+            raise RuntimeError(f"Size reference loop detected")
         axes_sizes = others.get(self.reference.tensor_id)
         if axes_sizes is None:
             return None

--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -324,7 +324,6 @@ class IndexTimeSpaceAxisBase(AxisBase):
         Field(
             examples=[
                 FixedSize(extent=10),
-                "other_axis",
                 ParameterizedSize(min=32, step=16).model_dump(),
                 SizeReference(
                     reference=TensorAxisId(tensor_id="other_tensor", axis_id="other_axis"),

--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -230,6 +230,7 @@ class SizeReference(Node):
 AxisSize: TypeAlias = Union[FixedSize, SizeReference, ParameterizedSize]
 
 def resolve_sizes(slots: Sequence["InputTensorDescr | OutputTensorDescr"]) -> Mapping[TensorAxisId, "FixedSize | ParameterizedSize"]:
+    #FIXME: don't allow channels to reference non-channel axes?
     resolved_sizes: Dict[TensorAxisId, "FixedSize | ParameterizedSize"] = {
         TensorAxisId(tensor_id=slot.id, axis_id=axis.id): axis.size
         for slot in slots
@@ -1207,6 +1208,7 @@ class ModelDescr(GenericModelDescrBase, title="bioimage.io model specification")
 
     @model_validator(mode="after")
     def validate_test_tensors(self, info: ValidationInfo) -> Self:
+        #FIXME: special-case batch axis?
         context = get_internal_validation_context(info.context)
         if not context["perform_io_checks"]:
             return self

--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -286,9 +286,16 @@ class WithHalo(Node):
 class BatchAxis(AxisBase):
     type: Literal["batch"] = "batch"
     id: Annotated[AxisId, Predicate(lambda x: x == AxisId("batch"))] = AxisId("batch")
-    size: Optional[Literal[1]] = None
+    batch_size: Optional[Literal[1]] = None
     """The batch size may be fixed to 1,
     otherwise (the default) it may be chosen arbitrarily depending on available memory"""
+
+    @property
+    def size(self) -> "FixedSize | ParameterizedSize":
+        if self.batch_size == 1:
+            return FixedSize(extent=1)
+        else:
+            return ParameterizedSize(min=1, step=1)
 
 
 class InferredChannels(SizeReference):

--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -34,7 +34,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from typing_extensions import Annotated, LiteralString, Self, assert_never
+from typing_extensions import Annotated, LiteralString, Self, TypeAlias, assert_never
 
 from bioimageio.spec._internal.base_nodes import Node, NodeWithExplicitlySetFields
 from bioimageio.spec._internal.constants import DTYPE_LIMITS, INFO
@@ -216,7 +216,7 @@ class SizeReference(Node):
     def try_resolve(
         self,
         *,
-        others: Mapping[TensorId, Mapping[AxisId, AxisSize]],
+        others: Mapping[TensorId, Mapping[AxisId, "AxisSize"]],
         visited: "Set[TensorId] | None" = None,
     ) -> "int | ParameterizedSize | None":
         visited = visited or set()

--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -174,23 +174,12 @@ PreprocessingId = Literal[
 
 SAME_AS_TYPE = "<same as type>"
 
-class ElementUnit(Node):
-    """How much each element of an array measures"""
-
-    unit: "TimeUnit | SpaceUnit" #FIXME?
-    scale: float = 1.0
-
-    def transformed(self, scale: float) -> ElementUnit:
-        return ElementUnit(unit=self.unit, scale=self.scale * scale)
-
 class FixedSize(Node):
     extent: int
-    element_unit: ElementUnit
 
     def transformed(self, *, scale: float = 1.0, offset: int = 0) -> "FixedSize":
         return FixedSize(
             extent=round(self.extent * scale) + offset,
-            element_unit=self.element_unit.transformed(scale=1 / scale)
         )
 
     def validate_size(self, size: int) -> int:
@@ -204,13 +193,11 @@ class ParameterizedSize(Node):
 
     min: Annotated[int, Gt(0)]
     step: Annotated[int, Gt(0)]
-    elemen_unit: ElementUnit
 
     def transformed(self, *, scale: float = 1.0, offset: int = 0) -> "ParameterizedSize":
         return ParameterizedSize(
             min=round(self.min * scale) + offset, #FIXME: does rounding make sense?
             step=round(self.step * scale), #FIXME: does rounding make sense?
-            elemen_unit=self.elemen_unit.transformed(scale=1 / scale),
         )
 
     def validate_size(self, size: int) -> int:

--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -300,6 +300,13 @@ class ChannelAxis(AxisBase):
     id: AxisId = AxisId("channel")
     size_descr: "InferredChannels | Sequence[Identifier]"
 
+    @property
+    def size(self) -> "FixedSize | SizeReference":
+        if isinstance(self.size_descr, InferredChannels):
+            return self.size_descr
+        else:
+            return FixedSize(extent=len(self.size_descr))
+
 class IndexTimeSpaceAxisBase(AxisBase):
     size: Annotated[
         AxisSize,

--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -178,10 +178,12 @@ SAME_AS_TYPE = "<same as type>"
 
 class FixedSize(Node):
     extent: int
+    unit: "TimeUnit | SpaceUnit" #FIXME: generic?
 
     def transformed(self, *, scale: float = 1.0, offset: int = 0) -> "FixedSize":
         return FixedSize(
             extent=round(self.extent * scale) + offset,
+            unit=self.unit,
         )
 
     def validate_size(self, size: int) -> int:
@@ -195,11 +197,13 @@ class ParameterizedSize(Node):
 
     min: Annotated[int, Gt(0)]
     step: Annotated[int, Gt(0)]
+    unit: "TimeUnit | SpaceUnit" #FIXME: generic?
 
     def transformed(self, *, scale: float = 1.0, offset: int = 0) -> "ParameterizedSize":
         return ParameterizedSize(
             min=round(self.min * scale) + offset, #FIXME: does rounding make sense?
             step=round(self.step * scale), #FIXME: does rounding make sense?
+            unit=self.unit,
         )
 
     def validate_size(self, size: int) -> int:

--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -183,6 +183,12 @@ class ParameterizedSize(Node):
     min: Annotated[int, Gt(0)]
     step: Annotated[int, Gt(0)]
 
+    def transformed(self, *, scale: float = 1.0, offset: int = 0) -> "ParameterizedSize":
+        return ParameterizedSize(
+            min=round(self.min * scale) + offset, #FIXME: does rounding make sense?
+            step=round(self.step * scale) #FIXME: does rounding make sense?
+        )
+
     def validate_size(self, size: int) -> int:
         if size < self.min:
             raise ValueError(f"size {size} < {self.min}")

--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -349,7 +349,6 @@ class TimeAxisBase(IndexTimeSpaceAxisBase):
     type: Literal["time"] = "time"
     id: AxisId = AxisId("time")
     unit: Optional[TimeUnit] = None
-    scale: Annotated[float, Gt(0)] = 1.0
 
 
 class TimeInputAxis(TimeAxisBase):
@@ -360,7 +359,6 @@ class SpaceAxisBase(IndexTimeSpaceAxisBase):
     type: Literal["space"] = "space"
     id: Annotated[AxisId, Field(examples=["x", "y", "z"])] = AxisId("x")
     unit: Optional[SpaceUnit] = None
-    scale: Annotated[float, Gt(0)] = 1.0
 
 
 class SpaceInputAxis(SpaceAxisBase):

--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -20,7 +20,6 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    cast,
 )
 
 import numpy as np
@@ -55,7 +54,7 @@ from bioimageio.spec._internal.types import RelativeFilePath as RelativeFilePath
 from bioimageio.spec._internal.types import ResourceId as ResourceId
 from bioimageio.spec._internal.types import Sha256 as Sha256
 from bioimageio.spec._internal.types import Version as Version
-from bioimageio.spec._internal.types.field_validation import AfterValidator, WithSuffix
+from bioimageio.spec._internal.types.field_validation import WithSuffix
 from bioimageio.spec._internal.validation_context import InternalValidationContext, get_internal_validation_context
 from bioimageio.spec.dataset.v0_3 import DatasetDescr as DatasetDescr
 from bioimageio.spec.dataset.v0_3 import LinkedDatasetDescr as LinkedDatasetDescr


### PR DESCRIPTION
This PR tries to streamline axis sizes, so that there are fewer special cases and so that it is easier to verify their correctness:

- All axes sizes are `FixedSize | ParameterizedSize | SizeReference`;
  - No more `int`s  or `str`s or `None` or whatver;
- Checking that the axes sizes are good is done in one go, after resolving all references;
- Unit is only specified in the non-reference sizes, so they can't conflict with the referent;
- Channel names are streamlined; either give all names or a reference and prefix/suffix;
- Reference-to-reference-to-reference... is supported;
- There is reference-loop detection;
- Less code;

TODO:
- [ ] Check that channel axes don't reference non-channel axes
- [ ] Special-case for batch axes? Does it come into play when looking at the test tensors?
- [ ] Probably move `TensorDataDescr` into `ChannelAxis`