### PR TITLE
fixed `RawNodeTransformer` to resolve names of files hosted on zenodo properly

### DIFF
--- a/bioimageio/spec/shared/node_transformer.py
+++ b/bioimageio/spec/shared/node_transformer.py
@@ -197,7 +197,14 @@ class RawNodePackageTransformer(NodeTransformer):
                 resource = self.root / resource
 
         elif isinstance(resource, URI):
-            name_from = pathlib.PurePath(resource.path or "unknown")
+            if (
+                resource.authority == "zenodo.org"
+                and resource.path.startswith("/api/records/")
+                and resource.path.endswith("/content")
+            ):
+                name_from = pathlib.PurePath(resource.path[: -len("/content")].strip("/"))
+            else:
+                name_from = pathlib.PurePath(resource.path or "unknown")
             folder_in_package = ""
         else:
             raise TypeError(f"Unexpected type {type(resource)} for {resource}")


### PR DESCRIPTION
Background - in ilastik we use `get_resource_package_content` to get the list of files for a given model. See #547 for more background.


Filenames would currently be resolved to "content", "content-0" and so on in case of multiple such files. Previously one could get the filenames in the keys.
Some functionality relies on at least having the file extensions, which currently would be omitted.

With this PR, the original filenames are restored by removing the "/content" bit from the zenodo urls.

`get_resource_package_content` resolves filenames correctly with this patch:

<details><summary>output of <code>get_resource_package_content</code> (abbreviated)</summary>

```python
'cover.png': URI(uri_string=None, scheme='https', authority='zenodo.org', path='/api/records/5874742/files/cover.png/content', query='', fragment=''),
 'documentation.md': URI(uri_string=None, scheme='https', authority='zenodo.org', path='/api/records/5874742/files/documentation.md/content', query='', fragment=''),
 'rdf.yaml': ...,
 'sample_input_0.tif': URI(uri_string=None, scheme='https', authority='zenodo.org', path='/api/records/5874742/files/sample_input_0.tif/content', query='', fragment=''),
 'sample_output_0.tif': URI(uri_string=None, scheme='https', authority='zenodo.org', path='/api/records/5874742/files/sample_output_0.tif/content', query='', fragment=''),
 'test_input_0.npy': URI(uri_string=None, scheme='https', authority='zenodo.org', path='/api/records/5874742/files/test_input_0.npy/content', query='', fragment=''),
 'test_output_0.npy': URI(uri_string=None, scheme='https', authority='zenodo.org', path='/api/records/5874742/files/test_output_0.npy/content', query='', fragment=''),
 'unet.py': URI(uri_string=None, scheme='https', authority='zenodo.org', path='/api/records/5874742/files/unet.py/content', query='', fragment=''),
 'weights-torchscript.pt': URI(uri_string=None, scheme='https', authority='zenodo.org', path='/api/records/5874742/files/weights-torchscript.pt/content', query='', fragment=''),
 'weights.pt': URI(uri_string=None, scheme='https', authority='zenodo.org', path='/api/records/5874742/files/weights.pt/content', query='', fragment=''),
 'zero_mean_unit_variance.ijm': URI(uri_string=None, scheme='https', authority='zenodo.org', path='/api/records/5874742/files/zero_mean_unit_variance.ijm/content', query='', fragment='')}
```

</details>

fixes #547 