### PR TITLE
prefer torchscript in ilastik

### DIFF
--- a/scripts/generate_weight_formats_overview.py
+++ b/scripts/generate_weight_formats_overview.py
@@ -15,7 +15,7 @@ WEIGHTS_FORMATS_OVERVIEW_PATH = (
 
 # defaults for transition period
 consumer_defaults = {
-    "ilastik": ["pytorch_state_dict", "onnx", "torchscript"],
+    "ilastik": ["torchscript", "pytorch_state_dict", "onnx"],
     "zero": ["keras_hdf5"],
     "deepimagej": ["torchscript", "tensorflow_saved_model_bundle"],
     "imjoy": ["onnx"],


### PR DESCRIPTION
`torchscript` weights seem less problematic than `pytorch_state_dict` and should be default for the downloader. We can decide in ilastik whether we want to switch it up.