### PR TITLE
Added per axis size parameter retrieval

### DIFF
--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -2093,7 +2093,7 @@ class ModelDescr(GenericModelDescrBase, title="bioimage.io model specification")
         return data
 
     def get_tensor_sizes(
-        self, n: ParameterizedSize.N, batch_size: int
+        self, ns: Dict[Tuple[TensorId, AxisId], ParameterizedSize.N], batch_size: int
     ) -> Dict[TensorId, Dict[AxisId, int]]:
         all_axes = {
             t.id: {a.id: a for a in t.axes} for t in chain(self.inputs, self.outputs)
@@ -2105,16 +2105,34 @@ class ModelDescr(GenericModelDescrBase, title="bioimage.io model specification")
             for a in t_descr.axes:
                 if a.size is None:
                     assert isinstance(a, BatchAxis)
+                    if (t_descr.id, a.id) in ns:
+                        raise ValueError(
+                            f"No size increment factor (n) for batch axis of tensor {t_descr.id} expected."
+                        )
                     s = batch_size
                 elif isinstance(a.size, int):
+                    if (t_descr.id, a.id) in ns:
+                        raise ValueError(
+                            f"No size increment factor (n) for fixed size axis {a.id} of tensor {t_descr.id} expected."
+                        )
                     s = a.size
                 elif isinstance(a.size, ParameterizedSize):
-                    s = a.size.get_size(n)
+                    if (t_descr.id, a.id) not in ns:
+                        raise ValueError(
+                            f"Size increment factor (n) not given for axis {a.id} of tensor {t_descr.id}."
+                        )
+                    s = a.size.get_size(ns[(t_descr.id, a.id)])
                 elif isinstance(a.size, SizeReference):
                     assert not isinstance(a, BatchAxis)
                     ref_axis = all_axes[a.size.tensor_id][a.size.axis_id]
                     assert not isinstance(ref_axis, BatchAxis)
-                    s = a.size.get_size(axis=a, ref_axis=ref_axis, n=n)
+                    if (a.size.tensor_id, a.size.axis_id) not in ns:
+                        raise ValueError(
+                            f"No increment (n) provided for axis {a.id} of tensor {t_descr.id}. Expected reference from tensor {a.size.tensor_id} and axis {a.size.axis_id}."
+                        )
+                    s = a.size.get_size(
+                        axis=a, ref_axis=ref_axis, n=ns[(t_descr.id, a.id)]
+                    )
                 else:
                     assert_never(a.size)
 

--- a/tests/test_model/test_v0_5.py
+++ b/tests/test_model/test_v0_5.py
@@ -360,6 +360,31 @@ def test_output_fixed_shape_too_small(model_data: Dict[str, Any]):
     assert summary.status == "failed", summary.format()
 
 
+def test_get_tensor_sizes_raises_with_surplus_n(model_data: Dict[str, Any]):
+    with ValidationContext(perform_io_checks=False):
+        model = ModelDescr(**model_data)
+
+    output_tensor_id = model.inputs[0].id
+    output_axis_id = AxisId("y")
+
+    with pytest.raises(ValueError):
+        model.get_tensor_sizes(ns={(output_tensor_id, output_axis_id): 1}, batch_size=1)
+
+
+def test_get_tensor_sizes_raises_with_missing_n(model_data: Dict[str, Any]):
+    model_data["outputs"][0]["axes"][2] = {
+        "type": "space",
+        "id": "x",
+        "size": {"tensor_id": "input_1", "axis_id": "x"},
+        "halo": 0,
+    }
+
+    with ValidationContext(perform_io_checks=False):
+        model = ModelDescr(**model_data)
+    with pytest.raises(ValueError):
+        model.get_tensor_sizes(ns={}, batch_size=1)
+
+
 def test_output_ref_shape_mismatch(model_data: Dict[str, Any]):
     model_data["outputs"][0]["axes"][2] = {
         "type": "space",


### PR DESCRIPTION
Todos:
- [ ] there are pyright errors in the test (which I did not touch)
- [ ] add test that checks actual retrieval
- [ ] Discuss whether being strict is the right thing (right now, if there is parametrized axes, the `ns` parameter will assume no defaults)


<details><summary>pyright errors in tests</summary>

```
.../spec-bioimage-io/tests/test_model/test_v0_5.py
  .../spec-bioimage-io/tests/test_model/test_v0_5.py:32:28 - error: "UNET2D_ROOT" is unknown import symbol (reportAttributeAccessIssue)
  .../spec-bioimage-io/tests/test_model/test_v0_5.py:52:28 - error: Argument of type "list[dict[str, str | list[str]]]" cannot be assigned to parameter "axes" of type "_VT@dict" in function "__init__"
    "Literal['channel']" is incompatible with "list[str]" (reportArgumentType)
  .../spec-bioimage-io/tests/test_model/test_v0_5.py:62:17 - error: Argument of type "list[dict[str, str | list[str]]]" cannot be assigned to parameter "axes" of type "_VT@dict" in function "__init__"
    Type "dict[str, str | list[str]]" cannot be assigned to type "dict[str, list[int]] | dict[str, str]"
      "dict[str, str | list[str]]" is incompatible with "dict[str, list[int]]"
        Type parameter "_VT@dict" is invariant, but "str | list[str]" is not the same as "list[int]"
        Consider switching from "dict" to "Mapping" which is covariant in the value type
      "dict[str, str | list[str]]" is incompatible with "dict[str, str]"
        Type parameter "_VT@dict" is invariant, but "str | list[str]" is not the same as "str"
        Consider switching from "dict" to "Mapping" which is covariant in the value type (reportArgumentType)
  .../spec-bioimage-io/tests/test_model/test_v0_5.py:73:23 - error: Argument of type "list[dict[str, str | list[str]]]" cannot be assigned to parameter "axes" of type "_VT@dict" in function "__init__"
    Type "dict[str, str | list[str]]" cannot be assigned to type "dict[str, list[str]] | dict[str, str]"
      "dict[str, str | list[str]]" is incompatible with "dict[str, list[str]]"
        Type parameter "_VT@dict" is invariant, but "str | list[str]" is not the same as "list[str]"
        Consider switching from "dict" to "Mapping" which is covariant in the value type
      "dict[str, str | list[str]]" is incompatible with "dict[str, str]"
        Type parameter "_VT@dict" is invariant, but "str | list[str]" is not the same as "str"
        Consider switching from "dict" to "Mapping" which is covariant in the value type (reportArgumentType)
  .../spec-bioimage-io/tests/test_model/test_v0_5.py:164:32 - error: Argument of type "list[dict[str, str | list[str]]]" cannot be assigned to parameter "axes" of type "_VT@dict" in function "__init__"
    "Literal['channel']" is incompatible with "list[str]" (reportArgumentType)
5 errors, 0 warnings, 0 informations
```
</summary>