### PR TITLE
Improve unions

### DIFF
--- a/bioimageio/spec/_internal/field_warning.py
+++ b/bioimageio/spec/_internal/field_warning.py
@@ -139,9 +139,11 @@ def issue_warning(
     value: Any,
     severity: WarningSeverity = WARNING,
     msg_context: Optional[Dict[str, Any]] = None,
+    field: Optional[str] = None,
 ):
     msg_context = {"value": value, "severity": severity, **(msg_context or {})}
     if severity >= validation_context_var.get().warning_level:
         raise PydanticCustomError("warning", msg, msg_context)
     elif validation_context_var.get().log_warnings:
-        logger.log(severity, msg.format(**msg_context))
+        log_msg = (field + ": " if field else "") + (msg.format(**msg_context))
+        logger.log(severity, log_msg)

--- a/bioimageio/spec/_internal/io.py
+++ b/bioimageio/spec/_internal/io.py
@@ -184,6 +184,12 @@ class RelativePathBase(RootModel[PurePath], Generic[AbsolutePathT], frozen=True)
 class RelativePath(
     RelativePathBase[Union[AbsoluteFilePath, AbsoluteDirectory, HttpUrl]], frozen=True
 ):
+    def model_post_init(self, __context: Any) -> None:
+        if not self.root.parts:  # an empty path can only be a directory
+            raise ValueError(f"{self.root} is not a valid file path.")
+
+        super().model_post_init(__context)
+
     def get_absolute(
         self, root: "RootHttpUrl | Path | AnyUrl"
     ) -> "AbsoluteFilePath | AbsoluteDirectory | HttpUrl":

--- a/bioimageio/spec/_internal/io.py
+++ b/bioimageio/spec/_internal/io.py
@@ -184,12 +184,6 @@ class RelativePathBase(RootModel[PurePath], Generic[AbsolutePathT], frozen=True)
 class RelativePath(
     RelativePathBase[Union[AbsoluteFilePath, AbsoluteDirectory, HttpUrl]], frozen=True
 ):
-    def model_post_init(self, __context: Any) -> None:
-        if not self.root.parts:  # an empty path can only be a directory
-            raise ValueError(f"{self.root} is not a valid file path.")
-
-        super().model_post_init(__context)
-
     def get_absolute(
         self, root: "RootHttpUrl | Path | AnyUrl"
     ) -> "AbsoluteFilePath | AbsoluteDirectory | HttpUrl":
@@ -205,6 +199,12 @@ class RelativePath(
 
 
 class RelativeFilePath(RelativePathBase[Union[AbsoluteFilePath, HttpUrl]], frozen=True):
+    def model_post_init(self, __context: Any) -> None:
+        if not self.root.parts:  # an empty path can only be a directory
+            raise ValueError(f"{self.root} is not a valid file path.")
+
+        super().model_post_init(__context)
+
     def get_absolute(
         self, root: "RootHttpUrl | Path | AnyUrl"
     ) -> "AbsoluteFilePath | HttpUrl":

--- a/bioimageio/spec/_internal/io.py
+++ b/bioimageio/spec/_internal/io.py
@@ -516,18 +516,20 @@ class HashKwargs(TypedDict):
     sha256: NotRequired[Optional[Sha256]]
 
 
-StrictFileSource = Union[HttpUrl, FilePath, RelativeFilePath]
+StrictFileSource = Annotated[
+    Union[HttpUrl, FilePath, RelativeFilePath], Field(union_mode="left_to_right")
+]
 _strict_file_source_adapter = TypeAdapter(StrictFileSource)
 
 
 def interprete_file_source(file_source: PermissiveFileSource) -> StrictFileSource:
+    if isinstance(file_source, (HttpUrl, Path)):
+        return file_source
+
     if isinstance(file_source, pydantic.AnyUrl):
         file_source = str(file_source)
 
-    if isinstance(file_source, str):
-        return _strict_file_source_adapter.validate_python(file_source)
-    else:
-        return file_source
+    return _strict_file_source_adapter.validate_python(file_source)
 
 
 def _get_known_hash(hash_kwargs: HashKwargs):

--- a/bioimageio/spec/_package.py
+++ b/bioimageio/spec/_package.py
@@ -23,6 +23,7 @@ from ._internal.io_utils import open_bioimageio_yaml, write_yaml, write_zip
 from ._internal.packaging_context import PackagingContext
 from ._internal.url import HttpUrl
 from ._internal.validation_context import validation_context_var
+from ._internal.warning_levels import ERROR
 from ._io import load_description
 from .model.v0_4 import ModelDescr as ModelDescr04
 from .model.v0_4 import WeightsFormat
@@ -253,11 +254,12 @@ def save_bioimageio_package(
         compression=compression,
         compression_level=compression_level,
     )
-    if isinstance((exported := load_description(output_path)), InvalidDescr):
-        raise ValueError(
-            f"Exported package '{output_path}' is invalid:"
-            + f" {exported.validation_summary}"
-        )
+    with validation_context_var.get().replace(warning_level=ERROR):
+        if isinstance((exported := load_description(output_path)), InvalidDescr):
+            raise ValueError(
+                f"Exported package '{output_path}' is invalid:"
+                + f" {exported.validation_summary}"
+            )
 
     return output_path
 

--- a/bioimageio/spec/collection/v0_2.py
+++ b/bioimageio/spec/collection/v0_2.py
@@ -177,9 +177,10 @@ class CollectionDescr(
             if entry.rdf_source is not None:
                 if not context.perform_io_checks:
                     issue_warning(
-                        "Skipping IO relying validation for collection[{i}]",
+                        "Skipping IO dependent validation (perform_io_checks=False)",
                         value=entry.rdf_source,
                         msg_context=dict(i=i),
+                        field=f"collection[{i}]",
                     )
                     continue
 

--- a/bioimageio/spec/common.py
+++ b/bioimageio/spec/common.py
@@ -6,6 +6,8 @@ from ._internal.io import BioimageioYamlSource as BioimageioYamlSource
 from ._internal.io import FileDescr as FileDescr
 from ._internal.io import Sha256 as Sha256
 from ._internal.io import YamlValue as YamlValue
+from ._internal.io_basics import AbsoluteDirectory as AbsoluteDirectory
+from ._internal.io_basics import AbsoluteFilePath as AbsoluteFilePath
 from ._internal.io_basics import FileName as FileName
 from ._internal.root_url import RootHttpUrl as RootHttpUrl
 from ._internal.types import FileSource as FileSource

--- a/bioimageio/spec/generic/_v0_3_converter.py
+++ b/bioimageio/spec/generic/_v0_3_converter.py
@@ -1,7 +1,15 @@
 import collections.abc
 import string
+from pathlib import Path
 
-from .._internal.io import BioimageioYamlContent
+import imageio
+from loguru import logger
+
+from .._internal.io import (
+    BioimageioYamlContent,
+    extract_file_name,
+    interprete_file_source,
+)
 from ._v0_2_converter import convert_from_older_format as convert_from_older_format_v0_2
 
 
@@ -19,6 +27,7 @@ def convert_from_older_format(data: BioimageioYamlContent) -> None:
     convert_from_older_format_v0_2(data)
 
     convert_attachments(data)
+    convert_cover_images(data)
 
     _ = data.pop("download_url", None)
     _ = data.pop("rdf_source", None)
@@ -36,3 +45,28 @@ def convert_attachments(data: BioimageioYamlContent) -> None:
     a = data.get("attachments")
     if isinstance(a, collections.abc.Mapping):
         data["attachments"] = tuple({"source": file} for file in a.get("files", []))  # type: ignore
+
+
+def convert_cover_images(data: BioimageioYamlContent) -> None:
+    covers = data.get("covers")
+    if not isinstance(covers, list):
+        return
+
+    for i in range(len(covers)):
+        c = covers[i]
+        if not isinstance(c, str):
+            continue
+
+        src = interprete_file_source(c)
+        fname = extract_file_name(src)
+
+        if not (fname.endswith(".tif") or fname.endswith(".tiff")):
+            continue
+
+        try:
+            image = imageio.imread(c)
+            c_path = (Path(".bioimageio_converter_cache") / fname).with_suffix(".png")
+            imageio.imwrite(c_path, image)
+            covers[i] = str(c_path.absolute())
+        except Exception as e:
+            logger.warning("failed to convert tif cover image: {}", e)

--- a/bioimageio/spec/generic/v0_2.py
+++ b/bioimageio/spec/generic/v0_2.py
@@ -81,6 +81,8 @@ VALID_COVER_IMAGE_EXTENSIONS = (
     ".jpg",
     ".png",
     ".svg",
+    ".tif",
+    ".tiff",
 )
 
 _WithImageSuffix = WithSuffix(VALID_COVER_IMAGE_EXTENSIONS, case_sensitive=False)

--- a/bioimageio/spec/generic/v0_2.py
+++ b/bioimageio/spec/generic/v0_2.py
@@ -85,7 +85,8 @@ VALID_COVER_IMAGE_EXTENSIONS = (
 
 _WithImageSuffix = WithSuffix(VALID_COVER_IMAGE_EXTENSIONS, case_sensitive=False)
 CoverImageSource = Annotated[
-    Union[HttpUrl, AbsoluteFilePath, RelativeFilePath],
+    Union[AbsoluteFilePath, RelativeFilePath, HttpUrl],
+    Field(union_mode="left_to_right"),
     _WithImageSuffix,
     include_in_package_serializer,
 ]
@@ -396,9 +397,7 @@ class GenericDescrBase(GenericModelDescrBase):
 
     license: Annotated[
         Union[LicenseId, DeprecatedLicenseId, str, None],
-        Field(
-            union_mode="left_to_right", examples=["CC0-1.0", "MIT", "BSD-2-Clause"]
-        ),
+        Field(union_mode="left_to_right", examples=["CC0-1.0", "MIT", "BSD-2-Clause"]),
     ] = None
     """A [SPDX license identifier](https://spdx.org/licenses/).
     We do not support custom license beyond the SPDX license list, if you need that please

--- a/bioimageio/spec/generic/v0_2.py
+++ b/bioimageio/spec/generic/v0_2.py
@@ -235,7 +235,7 @@ class GenericModelDescrBase(ResourceDescrBase):
             authors = [{"name": a} if isinstance(a, str) else a for a in authors]
 
         if not authors:
-            issue_warning("No author specified.", value=authors)
+            issue_warning("missing", value=authors, field="authors")
 
         return authors
 
@@ -249,7 +249,7 @@ class GenericModelDescrBase(ResourceDescrBase):
     @classmethod
     def _warn_empty_cite(cls, value: Any):
         if not value:
-            issue_warning("No cite entry specified.", value=value)
+            issue_warning("missing", value=value, field="cite")
 
         return value
 
@@ -412,11 +412,19 @@ class GenericDescrBase(GenericModelDescrBase):
         if isinstance(value, LicenseId):
             pass
         elif value is None:
-            issue_warning("missing license.", value=value)
+            issue_warning("missing", value=value, field="license")
         elif isinstance(value, DeprecatedLicenseId):
-            issue_warning("'{value}' is a deprecated license identifier.", value=value)
+            issue_warning(
+                "'{value}' is a deprecated license identifier.",
+                value=value,
+                field="license",
+            )
         elif isinstance(value, str):
-            issue_warning("'{value}' is an unknown license identifier.", value=value)
+            issue_warning(
+                "'{value}' is an unknown license identifier.",
+                value=value,
+                field="license",
+            )
         else:
             assert_never(value)
 

--- a/bioimageio/spec/generic/v0_3.py
+++ b/bioimageio/spec/generic/v0_3.py
@@ -92,6 +92,7 @@ def _validate_md_suffix(value: V_suffix) -> V_suffix:
 
 DocumentationSource = Annotated[
     Union[AbsoluteFilePath, RelativeFilePath, HttpUrl],
+    Field(union_mode="left_to_right"),
     AfterValidator(_validate_md_suffix),
     include_in_package_serializer,
 ]

--- a/bioimageio/spec/generic/v0_3.py
+++ b/bioimageio/spec/generic/v0_3.py
@@ -57,9 +57,9 @@ from .._internal.validator_annotations import (
 from .._internal.version_type import Version as Version
 from .._internal.warning_levels import ALERT, INFO
 from ._v0_3_converter import convert_from_older_format
-from .v0_2 import VALID_COVER_IMAGE_EXTENSIONS, CoverImageSource
 from .v0_2 import Author as _Author_v0_2
 from .v0_2 import BadgeDescr as BadgeDescr
+from .v0_2 import CoverImageSource
 from .v0_2 import Doi as Doi
 from .v0_2 import Maintainer as _Maintainer_v0_2
 from .v0_2 import OrcidId as OrcidId
@@ -71,6 +71,13 @@ KNOWN_SPECIFIC_RESOURCE_TYPES = (
     "dataset",
     "model",
     "notebook",
+)
+VALID_COVER_IMAGE_EXTENSIONS = (
+    ".gif",
+    ".jpeg",
+    ".jpg",
+    ".png",
+    ".svg",
 )
 
 

--- a/bioimageio/spec/model/v0_4.py
+++ b/bioimageio/spec/model/v0_4.py
@@ -131,7 +131,8 @@ class CallableFromDepencency(StringNode):
 class CallableFromFile(StringNode):
     _pattern = r"^.+:.+$"
     source_file: Annotated[
-        Union[HttpUrl, RelativeFilePath],
+        Union[RelativeFilePath, HttpUrl],
+        Field(union_mode="left_to_right"),
         include_in_package_serializer,
     ]
     """∈📦 Python module that implements `callable_name`"""
@@ -144,7 +145,9 @@ class CallableFromFile(StringNode):
         return dict(source_file=":".join(file_parts), callable_name=callname)
 
 
-CustomCallable = Union[CallableFromFile, CallableFromDepencency]
+CustomCallable = Annotated[
+    Union[CallableFromFile, CallableFromDepencency], Field(union_mode="left_to_right")
+]
 
 
 class Dependencies(StringNode):
@@ -268,10 +271,11 @@ class KerasHdf5WeightsDescr(WeightsEntryDescrBase):
     def _tfv(cls, value: Any):
         if value is None:
             issue_warning(
-                "Missing TensorFlow version. Please specify the TensorFlow version"
+                "missing. Please specify the TensorFlow version"
                 + " these weights were created with.",
                 value=value,
                 severity=ALERT,
+                field="tensorflow_version",
             )
         return value
 
@@ -292,6 +296,7 @@ class OnnxWeightsDescr(WeightsEntryDescrBase):
                 + " with.",
                 value=value,
                 severity=ALERT,
+                field="opset_version",
             )
         return value
 
@@ -348,10 +353,11 @@ class PytorchStateDictWeightsDescr(WeightsEntryDescrBase):
     def _ptv(cls, value: Any):
         if value is None:
             issue_warning(
-                "Missing PyTorch version. Please specify the PyTorch version these"
+                "missing. Please specify the PyTorch version these"
                 + " PyTorch state dict weights were created with.",
                 value=value,
                 severity=ALERT,
+                field="pytorch_version",
             )
         return value
 
@@ -367,10 +373,11 @@ class TorchscriptWeightsDescr(WeightsEntryDescrBase):
     def _ptv(cls, value: Any):
         if value is None:
             issue_warning(
-                "Missing PyTorch version. Please specify the PyTorch version these"
+                "missing. Please specify the PyTorch version these"
                 + " Torchscript weights were created with.",
                 value=value,
                 severity=ALERT,
+                field="pytorch_version",
             )
         return value
 
@@ -386,10 +393,11 @@ class TensorflowJsWeightsDescr(WeightsEntryDescrBase):
     def _tfv(cls, value: Any):
         if value is None:
             issue_warning(
-                "Missing TensorFlow version. Please specify the TensorFlow version"
+                "missing. Please specify the TensorFlow version"
                 + " these TensorflowJs weights were created with.",
                 value=value,
                 severity=ALERT,
+                field="tensorflow_version",
             )
         return value
 
@@ -409,10 +417,11 @@ class TensorflowSavedModelBundleWeightsDescr(WeightsEntryDescrBase):
     def _tfv(cls, value: Any):
         if value is None:
             issue_warning(
-                "Missing TensorFlow version. Please specify the TensorFlow version"
+                "missing. Please specify the TensorFlow version"
                 + " these Tensorflow saved model bundle weights were created with.",
                 value=value,
                 severity=ALERT,
+                field="tensorflow_version",
             )
         return value
 
@@ -444,7 +453,7 @@ class ImplicitOutputShape(Node):
     reference_tensor: TensorName
     """Name of the reference tensor."""
 
-    scale: NotEmpty[List[Union[float, None]]]
+    scale: NotEmpty[List[Optional[float]]]
     """output_pix/input_pix for each dimension.
     'null' values indicate new dimensions, whose length is defined by 2*`offset`"""
 

--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -1658,7 +1658,10 @@ class ArchitectureFromLibraryDescr(_ArchitectureCallableDescr):
     """Where to import the callable from, i.e. `from <import_from> import <callable>`"""
 
 
-ArchitectureDescr = Union[ArchitectureFromFileDescr, ArchitectureFromLibraryDescr]
+ArchitectureDescr = Annotated[
+    Union[ArchitectureFromFileDescr, ArchitectureFromLibraryDescr],
+    Field(union_mode="left_to_right"),
+]
 
 
 class _ArchFileConv(

--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -1845,6 +1845,7 @@ class WeightsDescr(Node):
                 + " already converted weights. They have to reference the weights format"
                 + " they were converted from as their `parent`.",
                 value=len(entries_wo_parent),
+                field="weights",
             )
 
         for wtype, entry in self:
@@ -1933,7 +1934,9 @@ class ModelDescr(GenericModelDescrBase, title="bioimage.io model specification")
         doc_content = doc_path.read_text()
         if not re.match("#.*[vV]alidation", doc_content):
             issue_warning(
-                "No '# Validation' (sub)section found in {value}.", value=value
+                "No '# Validation' (sub)section found in {value}.",
+                value=value,
+                field="documentation",
             )
 
         return value
@@ -2217,7 +2220,7 @@ class ModelDescr(GenericModelDescrBase, title="bioimage.io model specification")
     with a few restrictions listed [here](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat).
     (In Python a datetime object is valid, too)."""
 
-    training_data: Union[LinkedDataset, DatasetDescr, None] = None
+    training_data: Union[None, LinkedDataset, DatasetDescr] = None
     """The dataset used to train this model"""
 
     weights: WeightsDescr
@@ -2240,6 +2243,7 @@ class ModelDescr(GenericModelDescrBase, title="bioimage.io model specification")
                 "Failed to generate cover image(s): {e}",
                 value=self.covers,
                 msg_context=dict(e=e),
+                field="covers",
             )
         else:
             self.covers.extend(generated_covers)

--- a/scripts/generate_spec_documentation.py
+++ b/scripts/generate_spec_documentation.py
@@ -183,7 +183,7 @@ class AnnotationName:
             if t.discriminator:
                 parts.append(f"discriminator={t.discriminator}")
 
-            return "; ".join(parts)
+            return "; ".join(map(str, parts))
 
         s = self.slim(str(t))
         if s.startswith("Annotated["):

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     packages=find_namespace_packages(exclude=["tests"]),  # Required
     install_requires=[
         "annotated-types>=0.5.0",
+        "dotenv",
         "email_validator",
         "imageio",
         "loguru",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
     packages=find_namespace_packages(exclude=["tests"]),  # Required
     install_requires=[
         "annotated-types>=0.5.0",
-        "dotenv",
         "email_validator",
         "imageio",
         "loguru",
@@ -40,6 +39,7 @@ setup(
         "pydantic-settings",
         "pydantic>=2.6.3",
         "python-dateutil",
+        "python-dotenv",
         "ruyaml",
         "tqdm",
         "typing-extensions",

--- a/tests/test_internal/test_io.py
+++ b/tests/test_internal/test_io.py
@@ -11,7 +11,8 @@ from bioimageio.spec._internal.validation_context import ValidationContext
 def test_valid_relative_file_path(p: Any):
     from bioimageio.spec._internal.io import RelativeFilePath
 
-    _ = RelativeFilePath(p)
+    with ValidationContext(perform_io_checks=False):
+        _ = RelativeFilePath(p)
 
 
 @pytest.mark.parametrize(
@@ -28,4 +29,17 @@ def test_invalid_relative_file_path(p: Any):
     from bioimageio.spec._internal.io import RelativeFilePath
 
     with ValidationContext(perform_io_checks=False), pytest.raises(ValidationError):
+        _ = RelativeFilePath(p)
+
+
+@pytest.mark.parametrize(
+    "p",
+    [
+        PurePath(__file__).parent,
+    ],
+)
+def test_invalid_relative_file_path_io_check(p: Any):
+    from bioimageio.spec._internal.io import RelativeFilePath
+
+    with ValidationContext(perform_io_checks=True), pytest.raises(ValidationError):
         _ = RelativeFilePath(p)

--- a/tests/test_internal/test_io.py
+++ b/tests/test_internal/test_io.py
@@ -1,0 +1,31 @@
+from pathlib import PurePath
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from bioimageio.spec._internal.validation_context import ValidationContext
+
+
+@pytest.mark.parametrize("p", [PurePath("maybe_a_file"), "maybe_a_file"])
+def test_valid_relative_file_path(p: Any):
+    from bioimageio.spec._internal.io import RelativeFilePath
+
+    _ = RelativeFilePath(p)
+
+
+@pytest.mark.parametrize(
+    "p",
+    [
+        PurePath(),
+        PurePath(""),
+        PurePath("."),
+        PurePath("http://example.cm"),
+        PurePath("https://example.com"),
+    ],
+)
+def test_invalid_relative_file_path(p: Any):
+    from bioimageio.spec._internal.io import RelativeFilePath
+
+    with ValidationContext(perform_io_checks=False), pytest.raises(ValidationError):
+        _ = RelativeFilePath(p)


### PR DESCRIPTION
pydantic's "smart" union mode leads to evaluating more types after a match in order to look for a 'better' match.
in some cases we don't need/want that and can speed up validation and reduce the number of 'failing' web requests

this PR also includes some minor general improvements