### PR TITLE
add input axis flag `concatenable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ Made with [contrib.rocks](https://contrib.rocks).
 
 ### bioimageio.spec Python package
 
+#### bioimageio.spec 0.5.2
+
+* new patch version model 0.5.2
+
 #### bioimageio.spec 0.5.1
 
 * new patch version model 0.5.1
@@ -235,6 +239,11 @@ Made with [contrib.rocks](https://contrib.rocks).
 * `load_raw_resource_description` accepts `update_to_format` kwarg
 
 ### Resource Description Format Versions
+
+#### model 0.5.2
+
+* Non-breaking changes
+  * added `concatenable` flag to index, time and space input axes
 
 #### model 0.5.1
 

--- a/bioimageio/spec/VERSION
+++ b/bioimageio/spec/VERSION
@@ -1,3 +1,3 @@
 {
-    "version": "0.5.1post1"
+    "version": "0.5.2"
 }

--- a/bioimageio/spec/model/v0_5.py
+++ b/bioimageio/spec/model/v0_5.py
@@ -283,6 +283,8 @@ class SizeReference(Node):
     1. The axis and the referenced axis need to have the same unit (or no unit).
     2. Batch axes may not be referenced.
     3. Fractions are rounded down.
+    4. If the reference axis is `concatenable` the referencing axis is assumed to be
+        `concatenable` as well with the same block order.
 
     example:
     An unisotropic input image of w*h=100*49 pixels depicts a phsical space of 200*196mm².
@@ -434,6 +436,10 @@ class BatchAxis(AxisBase):
         return 1.0
 
     @property
+    def concatenable(self):
+        return True
+
+    @property
     def unit(self):
         return None
 
@@ -446,6 +452,10 @@ class ChannelAxis(AxisBase):
     @property
     def size(self) -> int:
         return len(self.channel_names)
+
+    @property
+    def concatenable(self):
+        return False
 
     @property
     def scale(self) -> float:
@@ -490,7 +500,12 @@ class _WithInputAxisSize(Node):
 
 
 class IndexInputAxis(IndexAxisBase, _WithInputAxisSize):
-    pass
+    concatenable: bool = False
+    """If a model has a `concatenable` input axis, it can be processed blockwise,
+    splitting a longer sample axis into blocks matching its input tensor description.
+    Output axes are concatenable if they have a `SizeReference` to a concatenable
+    input axis.
+    """
 
 
 class IndexOutputAxis(IndexAxisBase):
@@ -520,7 +535,12 @@ class TimeAxisBase(AxisBase):
 
 
 class TimeInputAxis(TimeAxisBase, _WithInputAxisSize):
-    pass
+    concatenable: bool = False
+    """If a model has a `concatenable` input axis, it can be processed blockwise,
+    splitting a longer sample axis into blocks matching its input tensor description.
+    Output axes are concatenable if they have a `SizeReference` to a concatenable
+    input axis.
+    """
 
 
 class SpaceAxisBase(AxisBase):
@@ -531,7 +551,12 @@ class SpaceAxisBase(AxisBase):
 
 
 class SpaceInputAxis(SpaceAxisBase, _WithInputAxisSize):
-    pass
+    concatenable: bool = False
+    """If a model has a `concatenable` input axis, it can be processed blockwise,
+    splitting a longer sample axis into blocks matching its input tensor description.
+    Output axes are concatenable if they have a `SizeReference` to a concatenable
+    input axis.
+    """
 
 
 _InputAxisUnion = Union[


### PR DESCRIPTION
initiated by @constantinpape feedback to the current version and as discussed with @constantinpape and @Tomaz-Vieira separately offline: we need to distinguish between the sample axis length and the block axis length, i.e. we need to know if the axis described has the size of the block or the sample.