### PR TITLE
validate urls with requests.get(..., stream=True) (0.5.2post3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ Made with [contrib.rocks](https://contrib.rocks).
 
 ### bioimageio.spec Python package
 
+#### bioimageio.spec 0.5.2post3
+
+* avoid full download when validating urls
+
 #### bioimageio.spec 0.5.2post2
 
 * resolve version (un)specific collection IDs, e.g. `load_description('affable-shark')`, `load_description('affable-shark/1')`

--- a/bioimageio/spec/VERSION
+++ b/bioimageio/spec/VERSION
@@ -1,3 +1,3 @@
 {
-    "version": "0.5.2post2"
+    "version": "0.5.2post3"
 }

--- a/bioimageio/spec/_internal/io_utils.py
+++ b/bioimageio/spec/_internal/io_utils.py
@@ -160,6 +160,10 @@ def _get_one_collection(url: str):
         return ret
 
     for entry in collection:
+        if entry["entry_sha256"] is None:
+            logger.debug("skipping {} with entry_sha256=None", entry["id"])
+            continue
+
         if not isinstance(entry, dict):
             logger.error("entry has type {}", type(entry))
             continue

--- a/bioimageio/spec/_internal/url.py
+++ b/bioimageio/spec/_internal/url.py
@@ -32,7 +32,7 @@ def _validate_url(url: Union[str, pydantic.HttpUrl]) -> pydantic.AnyUrl:
         )
 
     try:
-        response = requests.get(val_url, timeout=(3, 3))
+        response = requests.get(val_url, stream=True, timeout=(3, 3))
     except (
         requests.exceptions.ChunkedEncodingError,
         requests.exceptions.ContentDecodingError,


### PR DESCRIPTION
also log broken staged versions that have a sha256 of None with debug level when loading the collection 