### PR TITLE
Examples: Load PlantSeg from and package Cellpose to BioImage.IO model zoo

### DIFF
--- a/example/create_cellpose_description.ipynb
+++ b/example/create_cellpose_description.ipynb
@@ -1,0 +1,430 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create Model Description of A Cellpose Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from bioimageio.spec.common import ValidationError\n",
+    "from bioimageio.spec.model.v0_5 import ModelDescr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To see what does a `ModelDescr` need:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "9 validation errors for bioimage.io model specification\n",
+      "name\n",
+      "  Field required [type=missing, input_value={'format_version': '0.5.0', 'type': 'model'}, input_type=dict]\n",
+      "    For further information visit https://errors.pydantic.dev/2.7/v/missing\n",
+      "description\n",
+      "  Field required [type=missing, input_value={'format_version': '0.5.0', 'type': 'model'}, input_type=dict]\n",
+      "    For further information visit https://errors.pydantic.dev/2.7/v/missing\n",
+      "authors\n",
+      "  Field required [type=missing, input_value={'format_version': '0.5.0', 'type': 'model'}, input_type=dict]\n",
+      "    For further information visit https://errors.pydantic.dev/2.7/v/missing\n",
+      "cite\n",
+      "  Field required [type=missing, input_value={'format_version': '0.5.0', 'type': 'model'}, input_type=dict]\n",
+      "    For further information visit https://errors.pydantic.dev/2.7/v/missing\n",
+      "license\n",
+      "  Field required [type=missing, input_value={'format_version': '0.5.0', 'type': 'model'}, input_type=dict]\n",
+      "    For further information visit https://errors.pydantic.dev/2.7/v/missing\n",
+      "documentation\n",
+      "  Field required [type=missing, input_value={'format_version': '0.5.0', 'type': 'model'}, input_type=dict]\n",
+      "    For further information visit https://errors.pydantic.dev/2.7/v/missing\n",
+      "inputs\n",
+      "  Field required [type=missing, input_value={'format_version': '0.5.0', 'type': 'model'}, input_type=dict]\n",
+      "    For further information visit https://errors.pydantic.dev/2.7/v/missing\n",
+      "outputs\n",
+      "  Field required [type=missing, input_value={'format_version': '0.5.0', 'type': 'model'}, input_type=dict]\n",
+      "    For further information visit https://errors.pydantic.dev/2.7/v/missing\n",
+      "weights\n",
+      "  Field required [type=missing, input_value={'format_version': '0.5.0', 'type': 'model'}, input_type=dict]\n",
+      "    For further information visit https://errors.pydantic.dev/2.7/v/missing\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    my_model_descr = ModelDescr()  # type: ignore\n",
+    "except ValidationError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bioimageio.spec.model.v0_5 import (\n",
+    "    Author,\n",
+    "    AxisId,\n",
+    "    ChannelAxis,\n",
+    "    CiteEntry,\n",
+    "    Doi,\n",
+    "    FileDescr,\n",
+    "    Identifier,\n",
+    "    InputTensorDescr,\n",
+    "    IntervalOrRatioDataDescr,\n",
+    "    ModelDescr,\n",
+    "    OutputTensorDescr,\n",
+    "    PytorchStateDictWeightsDescr,\n",
+    "    SizeReference,\n",
+    "    SpaceInputAxis,\n",
+    "    SpaceOutputAxis,\n",
+    "    TensorId,\n",
+    "    TorchscriptWeightsDescr,\n",
+    "    WeightsDescr,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Input description"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_axes = [\n",
+    "    SpaceInputAxis(id=AxisId(\"z\"), size=32),\n",
+    "    ChannelAxis(channel_names=[Identifier(\"c1\"), Identifier(\"c2\")]),\n",
+    "    SpaceInputAxis(id=AxisId('y'), size=224),\n",
+    "    SpaceInputAxis(id=AxisId('x'), size=224),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_descr = IntervalOrRatioDataDescr(type='float32')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_input_path = Path('test_input.npy')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_descr = InputTensorDescr(\n",
+    "    id=TensorId(\"raw\"),\n",
+    "    axes=input_axes,\n",
+    "    test_tensor=FileDescr(source=test_input_path),\n",
+    "    data=data_descr,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Output description"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_axes = [\n",
+    "    SpaceOutputAxis(id=AxisId(\"z\"), size=SizeReference(tensor_id=TensorId('raw'), axis_id=AxisId('z'))),\n",
+    "    ChannelAxis(channel_names=[Identifier(\"flow1\"), Identifier(\"flow2\"), Identifier(\"flow3\")]),\n",
+    "    SpaceOutputAxis(id=AxisId(\"y\"), size=SizeReference(tensor_id=TensorId('raw'), axis_id=AxisId('y'))),\n",
+    "    SpaceOutputAxis(id=AxisId(\"x\"), size=SizeReference(tensor_id=TensorId('raw'), axis_id=AxisId('x'))),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_output_path = Path('test_output.npy')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_descr = OutputTensorDescr(\n",
+    "    id=TensorId(\"flow\"),\n",
+    "    axes=output_axes,\n",
+    "    test_tensor=FileDescr(source=test_output_path),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Model architecture"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bioimageio.spec.model.v0_5 import (\n",
+    "    ArchitectureFromLibraryDescr,\n",
+    "    Version,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Version(root='2.3.0')"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    import torch\n",
+    "except ImportError:\n",
+    "    pytorch_version = Version(\"1.15\")\n",
+    "else:\n",
+    "    pytorch_version = Version(torch.__version__)\n",
+    "\n",
+    "pytorch_version"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pytorch_architecture = ArchitectureFromLibraryDescr(callable=Identifier(\"CPnetWrapper\"), import_from=\"cpnet_wrapper\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bioimageio.spec.model.v0_5 import LicenseId\n",
+    "from bioimageio.spec.common import HttpUrl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2024-05-29 13:28:07.160\u001b[0m | Level 30\u001b[0m | \u001b[36mbioimageio.spec._internal.field_warning\u001b[0m:\u001b[36missue_warning\u001b[0m:\u001b[36m149\u001b[0m - documentation: No '# Validation' (sub)section found in https://github.com/kreshuklab/go-nuclear/blob/main/README.md.\u001b[0m\n",
+      "\u001b[32m2024-05-29 13:28:07.217\u001b[0m | Level 30\u001b[0m | \u001b[36mbioimageio.spec._internal.field_warning\u001b[0m:\u001b[36missue_warning\u001b[0m:\u001b[36m149\u001b[0m - covers: Failed to generate cover image(s): Failed to construct cover image from shape (32, 2, 224, 224)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "created descr!\n"
+     ]
+    }
+   ],
+   "source": [
+    "my_model_descr = ModelDescr(\n",
+    "    name=\"Cellpose Gold Nuclear 1135\",\n",
+    "    description=\"An experimental Cellpose nuclear model fine-tuned on ovules 1136, 1137, 1139, 1170 and tested on ovules 1135. A model for BioImage.IO team to test and develop post-processing tools.\",\n",
+    "    authors=[Author(name=\"Qin Yu\", affiliation=\"EMBL\", github_user=\"qin-yu\")],\n",
+    "    cite=[CiteEntry(text=\"For more details see the manuscript\", doi=Doi(\"10.1101/2024.02.19.580954\"))],\n",
+    "    license=LicenseId(\"MIT\"),\n",
+    "    documentation=HttpUrl(\"https://github.com/kreshuklab/go-nuclear/blob/main/README.md\"),\n",
+    "    git_repo=HttpUrl(\"https://github.com/kreshuklab/go-nuclear\"),\n",
+    "    inputs=[input_descr],\n",
+    "    outputs=[output_descr],\n",
+    "    weights=WeightsDescr(\n",
+    "        pytorch_state_dict=PytorchStateDictWeightsDescr(\n",
+    "            source=Path('/g/kreshuk/yu/temp/cp_wrapper_state_dict_1135_gold.pth'),\n",
+    "            architecture=pytorch_architecture,\n",
+    "            pytorch_version=pytorch_version\n",
+    "        ),\n",
+    "        torchscript=TorchscriptWeightsDescr(\n",
+    "            source=Path('/g/kreshuk/yu/temp/cp_wrapper_traced_1135_gold.pt'),\n",
+    "            pytorch_version=pytorch_version,\n",
+    "            parent=\"pytorch_state_dict\", # these weights were converted from the pytorch_state_dict weights ones.\n",
+    "        ),\n",
+    "    ),\n",
+    "    )\n",
+    "print(\"created descr!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Dynamic validation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2024-05-29 13:28:08.338\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbioimageio.core._resource_tests\u001b[0m:\u001b[36m_test_model_inference\u001b[0m:\u001b[36m122\u001b[0m - \u001b[1mstarting 'Reproduce test outputs from test inputs'\u001b[0m\n",
+      "\u001b[32m2024-05-29 13:28:15.527\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbioimageio.core._resource_tests\u001b[0m:\u001b[36m_test_model_inference_parametrized\u001b[0m:\u001b[36m192\u001b[0m - \u001b[1mTesting inference with 4 different input tensor sizes\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "\n",
+       "|        ✔️       | bioimageio validation passed |\n",
+       "|       ---       |             ---              |\n",
+       "| source          | in-memory                    |\n",
+       "| format version  | model 0.5.0                  |\n",
+       "| bioimageio.spec | 0.5.2post5                   |\n",
+       "| bioimageio.core | 0.6.5                        |\n",
+       "\n",
+       "|  ❓  | location |                                detail                               |\n",
+       "| --- |   ---    |                                 ---                                 |\n",
+       "| ✔️  |          | initialized ModelDescr to describe model 0.5.0                      |\n",
+       "|     |          |                                                                     |\n",
+       "| ✔️  |          | Has expected resource type                                          |\n",
+       "|     |          |                                                                     |\n",
+       "| ✔️  |          | Reproduce test outputs from test inputs                             |\n",
+       "|     |          |                                                                     |\n",
+       "| ✔️  |          | Run inference for inputs with batch_size: 1 and size parameter n: 0 |\n",
+       "|     |          |                                                                     |\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from bioimageio.core import test_model\n",
+    "summary = test_model(my_model_descr)\n",
+    "summary.display()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Package the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "package path: cellpose_gold_1135.zip\n"
+     ]
+    }
+   ],
+   "source": [
+    "from bioimageio.spec import save_bioimageio_package\n",
+    "\n",
+    "print(\"package path:\", save_bioimageio_package(my_model_descr, output_path=Path('cellpose_gold_1135.zip')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "plant-seg-bioimage-io",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/example/load_plantseg_models.ipynb
+++ b/example/load_plantseg_models.ipynb
@@ -1,0 +1,227 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load PlantSeg Models from BioImage.IO Model Zoo by Nicknames\n",
+    "\n",
+    "To get started, create a conda/mamba environment with both `plant-seg` and `bioimageio.spec` from `conda-forge` channel. You may choose to only install `bioimageio.spec` and avoid to run the very last cell (PlantSeg model loading)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import json\n",
+    "import pooch\n",
+    "\n",
+    "from bioimageio.spec import InvalidDescr, load_description\n",
+    "from bioimageio.spec.model.v0_4 import ModelDescr as ModelDescr_v0_4\n",
+    "from bioimageio.spec.model.v0_5 import ModelDescr as ModelDescr_v0_5\n",
+    "from bioimageio.spec.utils import download\n",
+    "\n",
+    "from plantseg.training.model import UNet2D, UNet3D"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BIOIMAGE_IO_COLLECTION_URL = \"https://raw.githubusercontent.com/bioimage-io/collection-bioimage-io/gh-pages/collection.json\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's filter the models by tags, which doesn't gaurantee to find all PlantSeg-compatible models, but it's quick:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _is_plantseg_model(collection_entry: dict) -> bool:\n",
+    "    \"\"\"Determines if the 'tags' field in a collection entry contains the keyword 'plantseg'.\"\"\"\n",
+    "    tags = collection_entry.get(\"tags\")\n",
+    "    if tags is None:\n",
+    "        return False\n",
+    "    if not isinstance(tags, list):\n",
+    "        raise ValueError(f\"Tags in a collection entry must be a list of strings, got {type(tags).__name__}\")\n",
+    "\n",
+    "    # Normalize tags to lower case and remove non-alphanumeric characters\n",
+    "    normalized_tags = [\"\".join(filter(str.isalnum, tag.lower())) for tag in tags]\n",
+    "    return 'plantseg' in normalized_tags"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'efficient-chipmunk',\n",
+       " 'emotional-cricket',\n",
+       " 'laid-back-lobster',\n",
+       " 'loyal-squid',\n",
+       " 'noisy-fish',\n",
+       " 'passionate-t-rex',\n",
+       " 'pioneering-rhino',\n",
+       " 'powerful-fish',\n",
+       " 'thoughtful-turtle'}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collection_path = Path(pooch.retrieve(BIOIMAGE_IO_COLLECTION_URL, known_hash=None))\n",
+    "with collection_path.open(encoding='utf-8') as f:\n",
+    "    collection = json.load(f)\n",
+    "bioimageio_zoo_collection = collection\n",
+    "bioimageio_zoo_plantseg_model_url_dict = {\n",
+    "    entry[\"nickname\"]: entry[\"rdf_source\"]\n",
+    "    for entry in collection[\"collection\"]\n",
+    "    if entry[\"type\"] == \"model\" and _is_plantseg_model(entry)\n",
+    "}\n",
+    "set(bioimageio_zoo_plantseg_model_url_dict.keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pick a model from the list and load it with `bioimageio.spec`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_id = 'efficient-chipmunk'\n",
+    "\n",
+    "if model_id not in bioimageio_zoo_plantseg_model_url_dict:\n",
+    "    raise ValueError(f\"Model ID {model_id} may not be a PlantSeg model in BioImage.IO Model Zoo\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Got plantseg.models.model.UNet3D model with kwargs {'f_maps': 16, 'in_channels': 1, 'out_channels': 2}.\n"
+     ]
+    }
+   ],
+   "source": [
+    "rdf_url = bioimageio_zoo_plantseg_model_url_dict[model_id]\n",
+    "model_description = load_description(rdf_url)\n",
+    "\n",
+    "# Check if description is `ResourceDescr`\n",
+    "if isinstance(model_description, InvalidDescr):\n",
+    "    model_description.validation_summary.display()\n",
+    "    raise ValueError(f\"Failed to load {model_id}\")\n",
+    "\n",
+    "# Check `model_description` has `weights`\n",
+    "if not isinstance(model_description, ModelDescr_v0_4) and not isinstance(model_description, ModelDescr_v0_5):\n",
+    "    raise ValueError(\n",
+    "        f\"Model description {model_id} is not in v0.4 or v0.5 BioImage.IO model description format. \"\n",
+    "        \"Only v0.4 and v0.5 formats are supported by BioImage.IO Spec and PlantSeg.\"\n",
+    "    )\n",
+    "\n",
+    "# Check `model_description.weights` has `pytorch_state_dict`\n",
+    "if model_description.weights.pytorch_state_dict is None:\n",
+    "    raise ValueError(f\"Model {model_id} does not have PyTorch weights\")\n",
+    "\n",
+    "# Spec format version v0.4 and v0.5 have different designs to store model architecture\n",
+    "if isinstance(model_description, ModelDescr_v0_4):  # then `pytorch_state_dict.architecture` is nn.Module\n",
+    "    architecture_callable = model_description.weights.pytorch_state_dict.architecture\n",
+    "    architecture_kwargs = model_description.weights.pytorch_state_dict.kwargs\n",
+    "elif isinstance(model_description, ModelDescr_v0_5):  # then it is `ArchitectureDescr` with `callable`\n",
+    "    architecture_callable = model_description.weights.pytorch_state_dict.architecture.callable\n",
+    "    architecture_kwargs = model_description.weights.pytorch_state_dict.architecture.kwargs\n",
+    "print(f\"Got {architecture_callable} model with kwargs {architecture_kwargs}.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created <class 'plantseg.training.model.UNet3D'> model with kwargs {'in_channels': 1, 'out_channels': 2, 'layer_order': 'gcr', 'f_maps': 16, 'num_groups': 8, 'final_sigmoid': True}.\n",
+      "Loaded model from BioImage.IO Model Zoo: efficient-chipmunk\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create model from architecture and kwargs\n",
+    "architecture = str(architecture_callable)  # e.g. 'plantseg.models.model.UNet3D'\n",
+    "architecture = UNet3D if 'UNet3D' in architecture else UNet2D\n",
+    "model_config = {\n",
+    "    'in_channels': 1,\n",
+    "    'out_channels': 1,\n",
+    "    'layer_order': 'gcr',\n",
+    "    'f_maps': 32,\n",
+    "    'num_groups': 8,\n",
+    "    'final_sigmoid': True,\n",
+    "}\n",
+    "model_config.update(architecture_kwargs)\n",
+    "model = architecture(**model_config)\n",
+    "model_weights_path = download(model_description.weights.pytorch_state_dict.source).path\n",
+    "\n",
+    "print(f\"Created {architecture} model with kwargs {model_config}.\")\n",
+    "print(f\"Loaded model from BioImage.IO Model Zoo: {model_id}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "plant-seg-bioimage-io",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Add a notebook to show how to search, download, and load PlantSeg models, adapted from PlantSeg's https://github.com/kreshuklab/plant-seg/pull/247

Some models are using architecture from dependencies which has no version specified. E.g. `plantseg.models.model.UNet3D` is moved to `plantseg.training.model.UNet3D`, and there is no way to find out. Therefore the very last step of loading this model depend on `plantseg`.