### PR TITLE
Automatic documentation

### DIFF
--- a/scripts/sphinx/Makefile
+++ b/scripts/sphinx/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/scripts/sphinx/make.bat
+++ b/scripts/sphinx/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/scripts/sphinx/requirements.txt
+++ b/scripts/sphinx/requirements.txt
@@ -1,2 +1,4 @@
 sphinx
+sphinx-pydantic
 bioimageio.spec
+sphinx-rtd-theme

--- a/scripts/sphinx/requirements.txt
+++ b/scripts/sphinx/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+bioimageio.spec

--- a/scripts/sphinx/source/conf.py
+++ b/scripts/sphinx/source/conf.py
@@ -17,16 +17,18 @@ release = '0.1.1'
 
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.napoleon'
+    'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon',
+    'sphinx-pydantic'
 ]
 
 templates_path = ['_templates']
-exclude_patterns = []
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']

--- a/scripts/sphinx/source/conf.py
+++ b/scripts/sphinx/source/conf.py
@@ -1,0 +1,32 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'bioimageio.spec.sphinx.doc'
+copyright = '2024, BioImageIO'
+author = 'Estibaliz'
+release = '0.1.1'
+
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon'
+]
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/scripts/sphinx/source/index.rst
+++ b/scripts/sphinx/source/index.rst
@@ -1,0 +1,20 @@
+.. bioimageio.spec.sphinx.doc documentation master file, created by
+   sphinx-quickstart on Thu Jun 13 12:54:52 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to bioimageio.spec.sphinx.doc's documentation!
+======================================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/scripts/sphinx/source/model.rst
+++ b/scripts/sphinx/source/model.rst
@@ -1,0 +1,25 @@
+
+.. automodule:: bioimageio.spec.model
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: bioimageio.spec.model.v0_4
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: bioimageio.spec.model.v0_4.ModelDescr
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: bioimageio.spec.model.v0_5
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: bioimageio.spec.model.v0_5.ModelDescr
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Automatic documentation generation using [sphinx for pydantic](https://sphinx-pydantic.readthedocs.io/en/latest/)

- All the files (`conf.py` and `.rst`) are inside the `/scripts/sphinx/source` folder.
- After the installation of requirements, run `make clean` followed by `make html` to compile the HTML with the documentation. 
- The new HTML doc is placed in `/scripts/sphinx/build` 

@Tomaz-Vieira @FynnBe and @oeway I started this but I'm not sure if the result is good, and if it can get any better using sphinx. Maybe heritageing some pydantic classes? The doc still looks quite complex to me.