### PR TITLE
Adds scripts for generating json schemas for humans

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,8 @@ jobs:
         run: python scripts/generate_spec_documentation.py --dist dist/user_docs
       - name: Generate JSON schemas
         run: python scripts/generate_json_schemas.py
+      - name: Generate JSON schema gui docs
+        run: python scripts/generate_json_schema_gui.py
       - id: get_version
         run: python -c 'import bioimageio.spec;print(f"version={bioimageio.spec.__version__}")' >> $GITHUB_OUTPUT
       - name: Generate developer docs

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Simplified descriptions are available as [JSON schema](https://json-schema.org/)
 | bioimageio.spec version | JSON schema |
 | --- | --- |
 | latest | [bioimageio_schema_latest.json](https://github.com/bioimage-io/spec-bioimage-io/blob/gh-pages/bioimageio_schema_latest.json) |
-| 0.5 | [bioimageio_schema_v0-5.json](https://github.com/bioimage-io/spec-bioimage-io/blob/gh-pages/bioimageio_schema_v0-5.json) |
+| 0.5 | [bioimageio_schema_v0-5.json](https://github.com/bioimage-io/spec-bioimage-io/blob/gh-pages/bioimageio_schema_v0-5.json) [rendered](https://github.com/bioimage-io/spec-bioimage-io/blob/gh-pages/json_schema_gui_v0-5/index.html)|
 
 These are primarily intended for syntax highlighting and form generation.
 

--- a/scripts/generate_json_schema_gui.py
+++ b/scripts/generate_json_schema_gui.py
@@ -1,0 +1,45 @@
+import sys
+import bioimageio.spec
+import tempfile
+import os
+from pathlib import Path
+import shutil
+from scripts.generate_json_schemas import MAJOR_MINOR_VERSION, export_json_schemas_from_type
+
+from json_schema_for_humans.generate import generate_from_filename # pyright: ignore [reportMissingTypeStubs]
+from json_schema_for_humans.generation_configuration import GenerationConfiguration # pyright: ignore [reportMissingTypeStubs]
+
+if __name__ == "__main__":
+    schema_file_handle, schema_file_path = tempfile.mkstemp()
+    os.close(schema_file_handle)
+
+    export_json_schemas_from_type(
+        output=Path(schema_file_path),
+        type_=bioimageio.spec.SpecificResourceDescr,
+        title="Model Description"
+    )
+
+    output_dir = Path(__file__).parent.parent / f"dist/json_schema_gui_{MAJOR_MINOR_VERSION}"
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True)
+
+    generate_from_filename(
+        schema_file_name=schema_file_path,
+        result_file_name=str(output_dir.joinpath("index.html")),
+        config=GenerationConfiguration(
+            # link_to_reused_ref=False,
+            deprecated_from_description=True,
+            default_from_description=True,
+            examples_as_yaml=True,
+            expand_buttons=True,
+            description_is_markdown=True,
+            copy_css=True,
+            copy_js=True,
+        )
+    )
+
+    print(f"Generated json schema docs at {output_dir}", file=sys.stderr)
+
+# Your doc is now in a file named "schema_doc.html". Next to it, "schema_doc.min.js" was copied, but not "schema_doc.css"
+# Your doc will contain a "Expand all" and a "Collapse all" button at the top

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ _ = setup(
             "jupyter",
             "lxml",
             "pdoc",
+            "json_schema_for_humans",
             "pre-commit",
             "psutil",  # parallel pytest with '-n auto'
             "pyright",


### PR DESCRIPTION
Adds scripts for generating json schemas for humans, as well as an entry in `build.yaml` to do it automatically with the other docs. One option (`link_to_reused_ref`) was causing encoding errors when writing out the HTML. This is marked as deprecated somewhere else in the `json-schema-for-humans` library code and it might not be in the tested paths. I can investigate that in later PRs if we care enough about it.



This PR also fixes the broken link pointing to the raw json schema.