### PR TITLE
Fixes breaking pyright checks across py versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       - run: ruff check **/*.py # ignore notebooks for now
         if: matrix.test-format
       - run: pyright --version
-      - run: pyright -p pyproject.toml
+      - run: pyright -p pyproject.toml --pythonversion ${{ matrix.python-version }}
       - run: pytest
 
   deploy:

--- a/bioimageio/spec/_internal/_settings.py
+++ b/bioimageio/spec/_internal/_settings.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Optional, Union
 
-import pooch
+import pooch # pyright: ignore [reportMissingTypeStubs]
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Annotated

--- a/bioimageio/spec/_internal/_settings.py
+++ b/bioimageio/spec/_internal/_settings.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Optional, Union
 
-import pooch # pyright: ignore [reportMissingTypeStubs]
+import pooch  # pyright: ignore [reportMissingTypeStubs]
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Annotated

--- a/bioimageio/spec/_internal/io.py
+++ b/bioimageio/spec/_internal/io.py
@@ -29,7 +29,7 @@ from typing import (
 from urllib.parse import urlparse, urlsplit, urlunsplit
 from zipfile import ZipFile, is_zipfile
 
-import pooch # pyright: ignore [reportMissingTypeStubs]
+import pooch  # pyright: ignore [reportMissingTypeStubs]
 import pydantic
 from pydantic import (
     AnyUrl,
@@ -222,7 +222,9 @@ PermissiveFileSource = Union[FileSource, str, pydantic.HttpUrl]
 
 V_suffix = TypeVar("V_suffix", bound=FileSource)
 # the type hints available for different python versions require this ignoring of reportUnknownVariableType
-path_or_url_adapter = TypeAdapter(Union[FilePath, DirectoryPath, HttpUrl]) # pyright: ignore [reportUnknownVariableType]
+path_or_url_adapter = TypeAdapter(
+    Union[FilePath, DirectoryPath, HttpUrl]
+)  # pyright: ignore [reportUnknownVariableType]
 
 
 def validate_suffix(

--- a/bioimageio/spec/_internal/io.py
+++ b/bioimageio/spec/_internal/io.py
@@ -222,7 +222,7 @@ PermissiveFileSource = Union[FileSource, str, pydantic.HttpUrl]
 
 V_suffix = TypeVar("V_suffix", bound=FileSource)
 # the type hints available for different python versions require this ignoring of reportUnknownVariableType
-path_or_url_adapter = TypeAdapter( # pyright: ignore [reportUnknownVariableType]
+path_or_url_adapter = TypeAdapter(  # pyright: ignore [reportUnknownVariableType]
     Union[FilePath, DirectoryPath, HttpUrl]
 )
 

--- a/bioimageio/spec/_internal/io.py
+++ b/bioimageio/spec/_internal/io.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+# pyright: reportUnnecessaryTypeIgnoreComment=warning
+
 import hashlib
 import sys
 import warnings
@@ -27,7 +29,7 @@ from typing import (
 from urllib.parse import urlparse, urlsplit, urlunsplit
 from zipfile import ZipFile, is_zipfile
 
-import pooch
+import pooch # pyright: ignore [reportMissingTypeStubs]
 import pydantic
 from pydantic import (
     AnyUrl,
@@ -219,7 +221,8 @@ FileSource = Annotated[
 PermissiveFileSource = Union[FileSource, str, pydantic.HttpUrl]
 
 V_suffix = TypeVar("V_suffix", bound=FileSource)
-path_or_url_adapter = TypeAdapter(Union[FilePath, DirectoryPath, HttpUrl])
+# the type hints available for different python versions require this ignoring of reportUnknownVariableType
+path_or_url_adapter = TypeAdapter(Union[FilePath, DirectoryPath, HttpUrl]) # pyright: ignore [reportUnknownVariableType]
 
 
 def validate_suffix(

--- a/bioimageio/spec/_internal/io.py
+++ b/bioimageio/spec/_internal/io.py
@@ -222,9 +222,9 @@ PermissiveFileSource = Union[FileSource, str, pydantic.HttpUrl]
 
 V_suffix = TypeVar("V_suffix", bound=FileSource)
 # the type hints available for different python versions require this ignoring of reportUnknownVariableType
-path_or_url_adapter = TypeAdapter(
+path_or_url_adapter = TypeAdapter( # pyright: ignore [reportUnknownVariableType]
     Union[FilePath, DirectoryPath, HttpUrl]
-)  # pyright: ignore [reportUnknownVariableType]
+)
 
 
 def validate_suffix(

--- a/scripts/generate_json_schemas.py
+++ b/scripts/generate_json_schemas.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, Literal, Final
 
-from deepdiff import DeepDiff
+from deepdiff import DeepDiff # pyright: ignore [reportMissingTypeStubs]
 from pydantic import ConfigDict, TypeAdapter
 from typing_extensions import assert_never
 

--- a/scripts/generate_json_schemas.py
+++ b/scripts/generate_json_schemas.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, Literal, Final
 
-from deepdiff import DeepDiff # pyright: ignore [reportMissingTypeStubs]
+from deepdiff import DeepDiff  # pyright: ignore [reportMissingTypeStubs]
 from pydantic import ConfigDict, TypeAdapter
 from typing_extensions import assert_never
 

--- a/tests/test_bioimageio_collection.py
+++ b/tests/test_bioimageio_collection.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping
 
-import pooch # pyright: ignore [reportMissingTypeStubs]
+import pooch  # pyright: ignore [reportMissingTypeStubs]
 import pytest
 
 from bioimageio.spec import settings

--- a/tests/test_bioimageio_collection.py
+++ b/tests/test_bioimageio_collection.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping
 
-import pooch
+import pooch # pyright: ignore [reportMissingTypeStubs]
 import pytest
 
 from bioimageio.spec import settings

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,7 +16,7 @@ from typing import (
 
 import jsonschema
 import pytest
-from deepdiff import DeepDiff
+from deepdiff import DeepDiff # pyright: ignore [reportMissingTypeStubs]
 from pydantic import (
     DirectoryPath,
     RootModel,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,7 +16,7 @@ from typing import (
 
 import jsonschema
 import pytest
-from deepdiff import DeepDiff # pyright: ignore [reportMissingTypeStubs]
+from deepdiff import DeepDiff  # pyright: ignore [reportMissingTypeStubs]
 from pydantic import (
     DirectoryPath,
     RootModel,


### PR DESCRIPTION
Pyright was failing depending on the python version being used; It seems the type hints available change depending on the python version, either because the hints are gated behind version checks or because the dependencies change versions to stay compatible with the python version.

This patch squelches some warnings and tells pyright to use the version of the current interpreter instead of always using `3.8` from `pyproject.toml`