### PR TITLE
Pins pyright to 1.1.378

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ _ = setup(
             "pdoc",
             "pre-commit",
             "psutil",  # parallel pytest with '-n auto'
-            "pyright",
+            "pyright==1.1.378",
             "pytest-xdist",  # parallel pytest
             "pytest",
             "python-devtools",


### PR DESCRIPTION
Pins pyright so the pipelines don't break when it becomes stricter.