### PR TITLE
Reduces border and padding noise

### DIFF
--- a/scripts/interactive_docs/__init__.py
+++ b/scripts/interactive_docs/__init__.py
@@ -14,6 +14,7 @@ def generate_docs(*, raw_type: Any, root_path: List[str]) -> "str | Exception":
         <!doctype html>
         <html>
             <head>
+                <meta charset="utf-8">
                 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/school-book.min.css">
                 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
                 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/yaml.min.js"></script>

--- a/scripts/interactive_docs/hint.py
+++ b/scripts/interactive_docs/hint.py
@@ -1421,8 +1421,13 @@ class Widget:
 
             /*border*/
             td, th{{
-                border-bottom: {theme_border};
                 border-collapse: collapse;
+            }}
+            tr{{
+                border-bottom: solid 1px black;
+            }}
+            tr:last-child{{
+                border-bottom: 0;
             }}
 
             th{{
@@ -1732,6 +1737,7 @@ class FieldsWidget(Widget):
                 font-weight: bold;
                 padding: 0.3em;
                 padding-right: 0;
+                padding-bottom: 0;
             }}
             .{cls.EXAMPLE_FIELD_CSS_CLASS}{{
                 background-color: #f6f5b2;

--- a/scripts/interactive_docs/hint.py
+++ b/scripts/interactive_docs/hint.py
@@ -1406,7 +1406,6 @@ class Widget:
             {subclasses_css}
 
             table{{
-                border: {theme_border};
                 border-collapse: collapse;
             }}
             th{{
@@ -1422,7 +1421,7 @@ class Widget:
 
             /*border*/
             td, th{{
-                border: {theme_border};
+                border-bottom: {theme_border};
                 border-collapse: collapse;
             }}
 
@@ -1663,7 +1662,7 @@ class ColumnControls(Widget):
         """
 
     def __init__(
-        self, root_element_id: str, style: str = "float: right; margin-left: 4em;"
+        self, root_element_id: str, style: str = "float: right; margin-left: 4em; margin-right: 1em;"
     ):
         # fmt: off
         super().__init__(
@@ -1732,6 +1731,7 @@ class FieldsWidget(Widget):
                 background-color: #84b4dd;
                 font-weight: bold;
                 padding: 0.3em;
+                padding-right: 0;
             }}
             .{cls.EXAMPLE_FIELD_CSS_CLASS}{{
                 background-color: #f6f5b2;


### PR DESCRIPTION
The interactive docs were relying a bit too much on borders and padding that created a bunch of visual noise. This PR eases that a bit while still maintaining a clear division between the fields:

Old (redundant borders and padding to the right):

![image](https://github.com/user-attachments/assets/32306e94-77b2-4ab2-9fc4-4e6d39139b1a)


New (removed borders and right-padding, trust indenting to represent nesting):

![image](https://github.com/user-attachments/assets/b62ecc75-6828-4c81-a50d-7b191ae18cf6)

