### PR TITLE
Add MicroSamWatershedDescr postprocessing

### DIFF
--- a/src/bioimageio/spec/model/v0_5.py
+++ b/src/bioimageio/spec/model/v0_5.py
@@ -1374,6 +1374,54 @@ class CellposeFlowDynamicsDescr(NodeWithExplicitlySetFields):
     kwargs: CellposeFlowDynamicsKwargs
 
 
+class MicroSamWatershedKwargs(KwargsNode):
+    """key word arguments for [MicroSamWatershedDescr][]"""
+
+    center_distance_threshold: float = 0.5
+    """Center distance predictions below this value are used to find seeds."""
+
+    boundary_distance_threshold: float = 0.5
+    """Boundary distance predictions below this value are used to find seeds."""
+
+    foreground_threshold: float = 0.5
+    """Foreground predictions above this value make up the foreground mask."""
+
+    foreground_smoothing: float = 1.0
+    """Sigma of the gaussian smoothing applied to the foreground prediction to
+    avoid checkerboard artifacts. Set to 0 to disable smoothing."""
+
+    distance_smoothing: float = 1.6
+    """Sigma of the gaussian smoothing applied to both distance predictions.
+    Set to 0 to disable smoothing."""
+
+    min_size: int = 0
+    """Minimum size of objects to keep, in pixels. Set to 0 to disable filtering by size."""
+
+    output_dtype: Literal["uint16", "uint32"] = "uint16"
+
+
+class MicroSamWatershedDescr(NodeWithExplicitlySetFields):
+    """micro-sam instance segmentation postprocessing as described in:
+    - Anna Archit, Luca Freckmann, Sushmita Nair, et al. [*Segment Anything for Microscopy*](https://www.nature.com/articles/s41592-024-02580-4). Nature Methods, 2025.
+
+    Turns the three dense maps predicted by a micro-sam instance segmentation
+    decoder (foreground probability, center distance, inverted boundary
+    distance) into instance labels with a seeded watershed.
+
+    Note: Only available if the `scikit-image` package is installed.
+    """
+
+    implemented_id: ClassVar[Literal["microsam_watershed"]] = "microsam_watershed"
+    if TYPE_CHECKING:
+        id: Literal["microsam_watershed"] = "microsam_watershed"
+    else:
+        id: Literal["microsam_watershed"]
+
+    kwargs: MicroSamWatershedKwargs = Field(
+        default_factory=MicroSamWatershedKwargs.model_construct
+    )
+
+
 class CustomProcessingDescr(NodeWithExplicitlySetFields, FileDescr):
     """Custom (post)processing op — source file shipped inline with the model.
 
@@ -1760,6 +1808,7 @@ PostprocessingDescr = Annotated[
         CustomProcessingDescr,
         EnsureDtypeDescr,
         FixedZeroMeanUnitVarianceDescr,
+        MicroSamWatershedDescr,
         ScaleLinearDescr,
         ScaleMeanVarianceDescr,
         ScaleRangeDescr,
@@ -2326,6 +2375,7 @@ class _InputTensorConv(
                 (
                     CellposeFlowDynamicsDescr,
                     CustomProcessingDescr,
+                    MicroSamWatershedDescr,
                     ScaleMeanVarianceDescr,
                     StardistPostprocessingDescr,
                 ),

--- a/src/bioimageio/spec/static/bioimageio_schema.json
+++ b/src/bioimageio/spec/static/bioimageio_schema.json
@@ -1346,6 +1346,78 @@
       "title": "model.v0_5.KerasV3WeightsDescr",
       "type": "object"
     },
+    "MicroSamWatershedDescr": {
+      "additionalProperties": false,
+      "description": "micro-sam instance segmentation postprocessing as described in:\n- Anna Archit, Luca Freckmann, Sushmita Nair, et al. [*Segment Anything for Microscopy*](https://www.nature.com/articles/s41592-024-02580-4). Nature Methods, 2025.\n\nTurns the three dense maps predicted by a micro-sam instance segmentation\ndecoder (foreground probability, center distance, inverted boundary\ndistance) into instance labels with a seeded watershed.\n\nNote: Only available if the `scikit-image` package is installed.",
+      "properties": {
+        "id": {
+          "const": "microsam_watershed",
+          "title": "Id",
+          "type": "string"
+        },
+        "kwargs": {
+          "$ref": "#/$defs/MicroSamWatershedKwargs"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "model.v0_5.MicroSamWatershedDescr",
+      "type": "object"
+    },
+    "MicroSamWatershedKwargs": {
+      "additionalProperties": false,
+      "description": "key word arguments for `MicroSamWatershedDescr`",
+      "properties": {
+        "center_distance_threshold": {
+          "default": 0.5,
+          "description": "Center distance predictions below this value are used to find seeds.",
+          "title": "Center Distance Threshold",
+          "type": "number"
+        },
+        "boundary_distance_threshold": {
+          "default": 0.5,
+          "description": "Boundary distance predictions below this value are used to find seeds.",
+          "title": "Boundary Distance Threshold",
+          "type": "number"
+        },
+        "foreground_threshold": {
+          "default": 0.5,
+          "description": "Foreground predictions above this value make up the foreground mask.",
+          "title": "Foreground Threshold",
+          "type": "number"
+        },
+        "foreground_smoothing": {
+          "default": 1.0,
+          "description": "Sigma of the gaussian smoothing applied to the foreground prediction to\navoid checkerboard artifacts. Set to 0 to disable smoothing.",
+          "title": "Foreground Smoothing",
+          "type": "number"
+        },
+        "distance_smoothing": {
+          "default": 1.6,
+          "description": "Sigma of the gaussian smoothing applied to both distance predictions.\nSet to 0 to disable smoothing.",
+          "title": "Distance Smoothing",
+          "type": "number"
+        },
+        "min_size": {
+          "default": 0,
+          "description": "Minimum size of objects to keep, in pixels. Set to 0 to disable filtering by size.",
+          "title": "Min Size",
+          "type": "integer"
+        },
+        "output_dtype": {
+          "default": "uint16",
+          "enum": [
+            "uint16",
+            "uint32"
+          ],
+          "title": "Output Dtype",
+          "type": "string"
+        }
+      },
+      "title": "model.v0_5.MicroSamWatershedKwargs",
+      "type": "object"
+    },
     "NominalOrOrdinalDataDescr": {
       "additionalProperties": false,
       "properties": {
@@ -12516,6 +12588,7 @@
                 "custom": "#/$defs/CustomProcessingDescr",
                 "ensure_dtype": "#/$defs/EnsureDtypeDescr",
                 "fixed_zero_mean_unit_variance": "#/$defs/FixedZeroMeanUnitVarianceDescr",
+                "microsam_watershed": "#/$defs/MicroSamWatershedDescr",
                 "scale_linear": "#/$defs/bioimageio__spec__model__v0_5__ScaleLinearDescr",
                 "scale_mean_variance": "#/$defs/bioimageio__spec__model__v0_5__ScaleMeanVarianceDescr",
                 "scale_range": "#/$defs/bioimageio__spec__model__v0_5__ScaleRangeDescr",
@@ -12544,6 +12617,9 @@
               },
               {
                 "$ref": "#/$defs/FixedZeroMeanUnitVarianceDescr"
+              },
+              {
+                "$ref": "#/$defs/MicroSamWatershedDescr"
               },
               {
                 "$ref": "#/$defs/bioimageio__spec__model__v0_5__ScaleLinearDescr"


### PR DESCRIPTION
## Motivation

micro-sam models with the additional instance segmentation (AIS) decoder predict three dense maps — foreground probability, center distance and inverted boundary distance. Turning those maps into instance labels requires a seeded watershed, which today only exists inside the `micro_sam` package. Making it a named postprocessing op lets a packaged, prompt-free micro-sam AIS model declare the step in its RDF instead of shipping a custom source file.

This adds the descriptor only. The implementation lives in bioimageio.core (bioimage-io/core-bioimage-io-python#501), whose operator needs a `bioimageio.spec.model.v0_5` type to bind `from_proc_descr` to.

## What is added

- `MicroSamWatershedKwargs` and `MicroSamWatershedDescr` (`id: microsam_watershed`), following the `CellposeFlowDynamicsDescr` precedent.
- Registration in the `PostprocessingDescr` union, and in the postprocessing-only exclusion tuple of `_InputTensorConv` (a postprocessing op cannot appear in a converted v0_4 preprocessing list).
- Regenerated `bioimageio_schema.json`.

Defaults match `micro_sam.instance_segmentation.InstanceSegmentationWithDecoder.generate` / `torch_em.util.segmentation.watershed_from_center_and_boundary_distances`: thresholds 0.5, foreground smoothing 1.0, distance smoothing 1.6, `min_size` 0. `output_dtype` mirrors `CellposeFlowDynamicsKwargs`. All fields have defaults, so `kwargs` may be omitted entirely.

## Format version

Not bumped here, mirroring the commit that introduced `CellposeFlowDynamicsDescr` (d53a39e8), which landed while `implemented_format_version` was still the previously released `0.5.9` and was bumped separately later. Happy to fold a bump to model `0.5.15` into this PR if you would rather release it that way.

## Test plan

- `MicroSamWatershedDescr` validates through the `PostprocessingDescr` discriminated union, with and without explicit kwargs.
- JSON schema regenerated with `scripts/generate_json_schema.py`; the diff is additive only.